### PR TITLE
fix(#89): add Vitest unit tests and fix test infrastructure

### DIFF
--- a/frontend/src/financeGPT/chatbot/messageUtils.test.js
+++ b/frontend/src/financeGPT/chatbot/messageUtils.test.js
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeSources,
+  parseRelevantChunks,
+  formatChatMessages,
+} from "./messageUtils";
+
+// ---------------------------------------------------------------------------
+// normalizeSources
+// ---------------------------------------------------------------------------
+
+describe("normalizeSources", () => {
+  it("returns empty array for null", () => {
+    expect(normalizeSources(null)).toEqual([]);
+  });
+
+  it("returns empty array for undefined", () => {
+    expect(normalizeSources(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for empty array", () => {
+    expect(normalizeSources([])).toEqual([]);
+  });
+
+  it("normalizes an object source", () => {
+    const result = normalizeSources([
+      { chunk_text: "Hello world", document_name: "doc.pdf", page_number: 3 },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].chunk_text).toBe("Hello world");
+    expect(result[0].document_name).toBe("doc.pdf");
+    expect(result[0].page_number).toBe(3);
+    expect(result[0].source_type).toBe("document_chunk");
+  });
+
+  it("normalizes an array-format source", () => {
+    const result = normalizeSources([["chunk text", "my_doc.pdf", 5, 0, 100]]);
+    expect(result).toHaveLength(1);
+    expect(result[0].chunk_text).toBe("chunk text");
+    expect(result[0].document_name).toBe("my_doc.pdf");
+    expect(result[0].page_number).toBe(5);
+    expect(result[0].start_index).toBe(0);
+    expect(result[0].end_index).toBe(100);
+  });
+
+  it("filters out null sources", () => {
+    const result = normalizeSources([null, undefined, { chunk_text: "ok", document_name: "d.pdf" }]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("handles camelCase aliases", () => {
+    const result = normalizeSources([
+      { chunkText: "text", documentName: "doc", pageNumber: 2 },
+    ]);
+    expect(result[0].chunk_text).toBe("text");
+    expect(result[0].document_name).toBe("doc");
+    expect(result[0].page_number).toBe(2);
+  });
+
+  it("defaults document_name when missing", () => {
+    const result = normalizeSources([{ chunk_text: "text" }]);
+    expect(result[0].document_name).toBe("Unknown document");
+  });
+
+  it("assigns sequential ids to array sources", () => {
+    const result = normalizeSources([
+      ["a", "doc1.pdf"],
+      ["b", "doc2.pdf"],
+    ]);
+    expect(result[0].id).toBe("source-0");
+    expect(result[1].id).toBe("source-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRelevantChunks
+// ---------------------------------------------------------------------------
+
+describe("parseRelevantChunks", () => {
+  it("returns empty array for null", () => {
+    expect(parseRelevantChunks(null)).toEqual([]);
+  });
+
+  it("returns empty array for non-string", () => {
+    expect(parseRelevantChunks(42)).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseRelevantChunks("")).toEqual([]);
+  });
+
+  it("parses a valid chunk string", () => {
+    const input = "Document: report.pdf: This is the relevant text.";
+    const result = parseRelevantChunks(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].document_name).toBe("report.pdf");
+    expect(result[0].chunk_text).toBe("This is the relevant text.");
+    expect(result[0].source_type).toBe("stored_relevant_chunk");
+  });
+
+  it("parses multiple chunks separated by double newline", () => {
+    const input = [
+      "Document: doc1.pdf: First chunk.",
+      "Document: doc2.pdf: Second chunk.",
+    ].join("\n\n");
+    const result = parseRelevantChunks(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].document_name).toBe("doc1.pdf");
+    expect(result[1].document_name).toBe("doc2.pdf");
+  });
+
+  it("ignores entries not starting with 'Document: '", () => {
+    const input = "Some random text\n\nDocument: real.pdf: actual content";
+    const result = parseRelevantChunks(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].document_name).toBe("real.pdf");
+  });
+
+  it("sets page_number to null", () => {
+    const result = parseRelevantChunks("Document: f.pdf: text");
+    expect(result[0].page_number).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatChatMessages
+// ---------------------------------------------------------------------------
+
+describe("formatChatMessages", () => {
+  const rawMessages = [
+    {
+      id: 1,
+      message_text: "Hello",
+      sent_from_user: 1,
+      relevant_chunks: null,
+      sources: null,
+      reasoning: null,
+      charts: null,
+      created: "2024-01-01T10:00:00Z",
+    },
+    {
+      id: 2,
+      message_text: "Hi there!",
+      sent_from_user: 0,
+      relevant_chunks: null,
+      sources: [{ chunk_text: "ctx", document_name: "d.pdf" }],
+      reasoning: [{ step: "think" }],
+      charts: [{ title: "chart1" }],
+      created: "2024-01-01T10:00:01Z",
+    },
+  ];
+
+  it("maps user messages to role=user", () => {
+    const result = formatChatMessages(rawMessages, 42);
+    expect(result[0].role).toBe("user");
+  });
+
+  it("maps bot messages to role=assistant", () => {
+    const result = formatChatMessages(rawMessages, 42);
+    expect(result[1].role).toBe("assistant");
+  });
+
+  it("copies message_text to content", () => {
+    const result = formatChatMessages(rawMessages, 42);
+    expect(result[0].content).toBe("Hello");
+    expect(result[1].content).toBe("Hi there!");
+  });
+
+  it("includes chat_id on each message", () => {
+    const result = formatChatMessages(rawMessages, 42);
+    result.forEach((msg) => expect(msg.chat_id).toBe(42));
+  });
+
+  it("includes sources from normalized sources when present", () => {
+    const result = formatChatMessages(rawMessages, 42);
+    expect(result[1].sources).toHaveLength(1);
+    expect(result[1].sources[0].chunk_text).toBe("ctx");
+  });
+
+  it("defaults reasoning to empty array", () => {
+    const result = formatChatMessages(rawMessages, 42);
+    expect(result[0].reasoning).toEqual([]);
+  });
+
+  it("includes charts", () => {
+    const result = formatChatMessages(rawMessages, 42);
+    expect(result[1].charts).toHaveLength(1);
+  });
+
+  it("converts created to timestamp", () => {
+    const result = formatChatMessages(rawMessages, 42);
+    expect(typeof result[0].timestamp).toBe("number");
+    expect(result[0].timestamp).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/redux/ChatSlice.test.js
+++ b/frontend/src/redux/ChatSlice.test.js
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import chatReducer, {
+  chatSlice,
+  clearChats,
+  clearError,
+  addChat,
+  setChatMessages,
+  evictChatMessages,
+  fetchAllChats,
+  deleteChat,
+  renameChat,
+  selectAllChats,
+  selectChatsLoading,
+  selectChatsError,
+  selectCachedMessages,
+} from "./ChatSlice";
+
+const initialState = {
+  chats: [],
+  loading: false,
+  error: null,
+  messagesByChat: {},
+};
+
+describe("ChatSlice initial state", () => {
+  it("has correct initial state shape", () => {
+    const state = chatReducer(undefined, { type: "@@INIT" });
+    expect(state).toEqual(initialState);
+  });
+});
+
+describe("ChatSlice synchronous reducers", () => {
+  it("clearChats empties chats and messagesByChat", () => {
+    const populated = {
+      ...initialState,
+      chats: [{ id: 1, chat_name: "Test" }],
+      messagesByChat: { "1": [{ id: 10 }] },
+    };
+    const next = chatReducer(populated, clearChats());
+    expect(next.chats).toEqual([]);
+    expect(next.messagesByChat).toEqual({});
+  });
+
+  it("clearError sets error to null", () => {
+    const withError = { ...initialState, error: "something went wrong" };
+    const next = chatReducer(withError, clearError());
+    expect(next.error).toBeNull();
+  });
+
+  it("addChat prepends to chats array", () => {
+    const existing = { ...initialState, chats: [{ id: 2 }] };
+    const next = chatReducer(existing, addChat({ id: 1, chat_name: "New" }));
+    expect(next.chats[0]).toEqual({ id: 1, chat_name: "New" });
+    expect(next.chats).toHaveLength(2);
+  });
+
+  it("setChatMessages stores messages keyed by string chatId", () => {
+    const next = chatReducer(
+      initialState,
+      setChatMessages({ chatId: 5, messages: [{ id: 99 }] })
+    );
+    expect(next.messagesByChat["5"]).toEqual([{ id: 99 }]);
+  });
+
+  it("evictChatMessages removes the cached entry", () => {
+    const withCache = {
+      ...initialState,
+      messagesByChat: { "5": [{ id: 99 }], "6": [{ id: 100 }] },
+    };
+    const next = chatReducer(withCache, evictChatMessages(5));
+    expect(next.messagesByChat["5"]).toBeUndefined();
+    expect(next.messagesByChat["6"]).toBeDefined();
+  });
+});
+
+describe("ChatSlice extraReducers — fetchAllChats", () => {
+  it("pending sets loading=true and clears error", () => {
+    const next = chatReducer(
+      { ...initialState, error: "old error" },
+      fetchAllChats.pending("req-id")
+    );
+    expect(next.loading).toBe(true);
+    expect(next.error).toBeNull();
+  });
+
+  it("fulfilled sets chats and clears loading", () => {
+    const chats = [{ id: 1 }, { id: 2 }];
+    const next = chatReducer(
+      { ...initialState, loading: true },
+      fetchAllChats.fulfilled(chats, "req-id")
+    );
+    expect(next.loading).toBe(false);
+    expect(next.chats).toEqual(chats);
+    expect(next.error).toBeNull();
+  });
+
+  it("fulfilled with undefined payload defaults to empty array", () => {
+    const next = chatReducer(
+      initialState,
+      fetchAllChats.fulfilled(undefined, "req-id")
+    );
+    expect(next.chats).toEqual([]);
+  });
+
+  it("rejected sets error and clears loading", () => {
+    const next = chatReducer(
+      { ...initialState, loading: true },
+      fetchAllChats.rejected(null, "req-id", undefined, "network error")
+    );
+    expect(next.loading).toBe(false);
+    expect(next.error).toBe("network error");
+  });
+});
+
+describe("ChatSlice extraReducers — deleteChat", () => {
+  const stateWithChats = {
+    ...initialState,
+    chats: [
+      { id: 1, chat_name: "First" },
+      { id: 2, chat_name: "Second" },
+    ],
+    messagesByChat: { "1": [], "2": [] },
+  };
+
+  it("pending sets loading=true", () => {
+    const next = chatReducer(stateWithChats, deleteChat.pending("req-id"));
+    expect(next.loading).toBe(true);
+  });
+
+  it("fulfilled removes the chat and its message cache", () => {
+    const next = chatReducer(
+      stateWithChats,
+      deleteChat.fulfilled(1, "req-id")
+    );
+    expect(next.chats).toHaveLength(1);
+    expect(next.chats[0].id).toBe(2);
+    expect(next.messagesByChat["1"]).toBeUndefined();
+    expect(next.messagesByChat["2"]).toBeDefined();
+  });
+
+  it("rejected sets error", () => {
+    const next = chatReducer(
+      stateWithChats,
+      deleteChat.rejected(null, "req-id", undefined, "delete failed")
+    );
+    expect(next.error).toBe("delete failed");
+    expect(next.loading).toBe(false);
+  });
+});
+
+describe("ChatSlice extraReducers — renameChat", () => {
+  const stateWithChats = {
+    ...initialState,
+    chats: [{ id: 3, chat_name: "Old Name" }],
+  };
+
+  it("fulfilled updates chat_name in the array", () => {
+    const next = chatReducer(
+      stateWithChats,
+      renameChat.fulfilled({ chatId: 3, chatName: "New Name" }, "req-id")
+    );
+    expect(next.chats[0].chat_name).toBe("New Name");
+    expect(next.error).toBeNull();
+  });
+
+  it("fulfilled is a no-op when chatId is not found", () => {
+    const next = chatReducer(
+      stateWithChats,
+      renameChat.fulfilled({ chatId: 99, chatName: "X" }, "req-id")
+    );
+    expect(next.chats[0].chat_name).toBe("Old Name");
+  });
+
+  it("rejected sets error", () => {
+    const next = chatReducer(
+      stateWithChats,
+      renameChat.rejected(null, "req-id", undefined, "rename failed")
+    );
+    expect(next.error).toBe("rename failed");
+  });
+});
+
+describe("ChatSlice selectors", () => {
+  const rootState = {
+    chatReducer: {
+      chats: [{ id: 1 }],
+      loading: true,
+      error: "err",
+      messagesByChat: { "1": [{ id: 10 }] },
+    },
+  };
+
+  it("selectAllChats returns chats array", () => {
+    expect(selectAllChats(rootState)).toEqual([{ id: 1 }]);
+  });
+
+  it("selectChatsLoading returns loading flag", () => {
+    expect(selectChatsLoading(rootState)).toBe(true);
+  });
+
+  it("selectChatsError returns error", () => {
+    expect(selectChatsError(rootState)).toBe("err");
+  });
+
+  it("selectCachedMessages returns messages for chatId", () => {
+    expect(selectCachedMessages(1)(rootState)).toEqual([{ id: 10 }]);
+  });
+
+  it("selectCachedMessages returns null for unknown chatId", () => {
+    expect(selectCachedMessages(999)(rootState)).toBeNull();
+  });
+
+  it("selectAllChats defaults to empty array when chatReducer missing", () => {
+    expect(selectAllChats({})).toEqual([]);
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Alias jest to vi so pre-existing jest-style tests work under Vitest
+import { vi } from "vitest";
+globalThis.jest = vi;

--- a/frontend/src/subcomponents/api/APISKeyDashboard.test.js
+++ b/frontend/src/subcomponents/api/APISKeyDashboard.test.js
@@ -2,32 +2,31 @@ import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { APISKeyDashboard } from "./APISKeyDashboard";
+import { vi } from "vitest";
 
-const mockDispatch = jest.fn();
-const mockGetAPIKeys = jest.fn(() => ({ type: "user/getAPIKeys" }));
-const mockNavigate = jest.fn();
+const mockDispatch = vi.fn();
+const mockGetAPIKeys = vi.fn(() => ({ type: "user/getAPIKeys" }));
+const mockNavigate = vi.fn();
 
-jest.mock("react-redux", () => ({
+vi.mock("react-redux", () => ({
   useDispatch: () => mockDispatch,
 }));
 
-jest.mock("../../redux/UserSlice", () => ({
+vi.mock("../../redux/UserSlice", () => ({
   useAPIKeys: () => [],
   useNumCredits: () => 3,
-  generateAPIKey: jest.fn(),
-  deleteAPIKey: jest.fn(),
+  generateAPIKey: vi.fn(),
+  deleteAPIKey: vi.fn(),
   getAPIKeys: (...args) => mockGetAPIKeys(...args),
 }));
 
-jest.mock("copy-to-clipboard", () => jest.fn());
+vi.mock("copy-to-clipboard", () => ({ default: vi.fn() }));
 
-jest.mock("@fortawesome/react-fontawesome", () => ({
+vi.mock("@fortawesome/react-fontawesome", () => ({
   FontAwesomeIcon: () => null,
 }));
 
-jest.mock("flowbite-react", () => {
-  const React = require("react");
-
+vi.mock("flowbite-react", () => {
   const sanitizeProps = ({ color, outline, show, size, ...props }) => props;
   const passthrough = ({ children, ...props }) =>
     React.createElement("div", sanitizeProps(props), children);
@@ -59,8 +58,8 @@ jest.mock("flowbite-react", () => {
   };
 });
 
-jest.mock("react-router-dom", () => {
-  const actual = jest.requireActual("react-router-dom");
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  esbuild: {
+    include: /\.[jt]sx?$/,
+    exclude: [],
+    loader: "jsx",
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["src/setupTests.js"],
+    include: ["src/**/*.test.{js,jsx,ts,tsx}"],
+    exclude: ["node_modules"],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `vitest.config.js` with globals, jsdom environment, and React JSX support via `@vitejs/plugin-react`
- Adds jest→vi compatibility shim in `setupTests.js` so existing tests work under Vitest
- Adds `messageUtils.test.js`: 24 tests for `normalizeSources`, `parseRelevantChunks`, `formatChatMessages`
- Adds `ChatSlice.test.js`: 22 tests covering all reducers, extraReducers, and selectors
- Fixes `APISKeyDashboard.test.js` to use `vi.mock`/`vi.fn` (vitest-compatible)
- All 52 tests pass

## Test plan
- [ ] `cd frontend && npm run test:run` → 52 tests pass, 0 failures

Closes #89

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu