### PR TITLE
feat(#94): add feature flags for FinanceGPT and agent system

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,7 @@ DB_NAME=
 DB_HOST=
 DB_PASSWORD=
 DB_USER=
+
+# Feature flags (set to "false" to disable; default: enabled)
+ENABLE_FINANCE_GPT=true
+ENABLE_AGENTS=true

--- a/backend/app.py
+++ b/backend/app.py
@@ -95,31 +95,35 @@ from google.oauth2 import id_token
 from google_auth_oauthlib.flow import Flow
 from jwt import InvalidTokenError
 from pip._vendor import cachecontrol
-from services.finance_gpt import (
-    _get_model,
-    chunk_document,
-    fetch_external_url,
-    get_relevant_chunks,
-    get_text_from_url,
-)
 from tika import parser as p
-from api_endpoints.financeGPT.chatbot_endpoints import (
-    serialize_sources_for_api,
-    sources_to_prompt_context,
-)
-
-_get_model()
 from datetime import datetime
 
+from features import is_finance_gpt_enabled, is_agent_enabled
 from agents.config import AgentConfig
-from agents.autonomous_agent import AutonomousDocumentAgent
-from agents.reactive_agent import ReactiveDocumentAgent
 from api_endpoints.languages.arabic import arabic_blueprint
 from api_endpoints.languages.chinese import chinese_blueprint
 from api_endpoints.languages.gtm import gpt4_blueprint
 from api_endpoints.languages.japanese import japanese_blueprint
 from api_endpoints.languages.korean import korean_blueprint
 from api_endpoints.languages.spanish import spanish_blueprint
+
+if is_finance_gpt_enabled():
+    from services.finance_gpt import (
+        _get_model,
+        chunk_document,
+        fetch_external_url,
+        get_relevant_chunks,
+        get_text_from_url,
+    )
+    from api_endpoints.financeGPT.chatbot_endpoints import (
+        serialize_sources_for_api,
+        sources_to_prompt_context,
+    )
+    _get_model()
+
+if is_agent_enabled():
+    from agents.autonomous_agent import AutonomousDocumentAgent
+    from agents.reactive_agent import ReactiveDocumentAgent
 
 load_dotenv(override=True)
 

--- a/backend/features.py
+++ b/backend/features.py
@@ -1,0 +1,33 @@
+"""
+Feature flags for the Anote AI backend.
+
+Each flag reads from an environment variable and defaults to ``True`` so that
+the full-featured deployment works out of the box.  Set the variable to
+``"false"`` (case-insensitive) to disable the feature.
+"""
+
+import os
+
+
+def _flag(env_var: str, default: bool = True) -> bool:
+    raw = os.getenv(env_var, "true" if default else "false")
+    return raw.strip().lower() not in ("false", "0", "no", "off")
+
+
+def is_finance_gpt_enabled() -> bool:
+    """Return True when the FinanceGPT / RAG chatbot feature is active.
+
+    Controlled by the ``ENABLE_FINANCE_GPT`` environment variable (default: enabled).
+    Disable to run as a plain chat-completion API server without document Q&A.
+    """
+    return _flag("ENABLE_FINANCE_GPT", default=True)
+
+
+def is_agent_enabled() -> bool:
+    """Return True when the autonomous-agent system is active.
+
+    This mirrors :py:meth:`agents.config.AgentConfig.is_agent_enabled` but is
+    accessible without importing the full agent stack.  Controlled by the
+    ``ENABLE_AGENTS`` environment variable (default: enabled).
+    """
+    return _flag("ENABLE_AGENTS", default=True)

--- a/backend/tests/test_features.py
+++ b/backend/tests/test_features.py
@@ -1,0 +1,75 @@
+"""Tests for backend/features.py feature-flag helpers."""
+
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def _reload_features():
+    """Re-import the features module so env vars picked up at import time are fresh."""
+    import features  # noqa: PLC0415
+    importlib.reload(features)
+    return features
+
+
+class TestIsFinanceGptEnabled:
+    def test_default_is_true(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ENABLE_FINANCE_GPT", None)
+            f = _reload_features()
+            assert f.is_finance_gpt_enabled() is True
+
+    def test_explicit_true(self):
+        with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "true"}):
+            f = _reload_features()
+            assert f.is_finance_gpt_enabled() is True
+
+    def test_explicit_false_lowercase(self):
+        with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "false"}):
+            f = _reload_features()
+            assert f.is_finance_gpt_enabled() is False
+
+    def test_explicit_false_uppercase(self):
+        with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "FALSE"}):
+            f = _reload_features()
+            assert f.is_finance_gpt_enabled() is False
+
+    def test_zero_disables(self):
+        with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "0"}):
+            f = _reload_features()
+            assert f.is_finance_gpt_enabled() is False
+
+    def test_off_disables(self):
+        with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "off"}):
+            f = _reload_features()
+            assert f.is_finance_gpt_enabled() is False
+
+    def test_one_enables(self):
+        with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "1"}):
+            f = _reload_features()
+            assert f.is_finance_gpt_enabled() is True
+
+
+class TestIsAgentEnabled:
+    def test_default_is_true(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ENABLE_AGENTS", None)
+            f = _reload_features()
+            assert f.is_agent_enabled() is True
+
+    def test_explicit_false(self):
+        with patch.dict(os.environ, {"ENABLE_AGENTS": "false"}):
+            f = _reload_features()
+            assert f.is_agent_enabled() is False
+
+    def test_explicit_true(self):
+        with patch.dict(os.environ, {"ENABLE_AGENTS": "true"}):
+            f = _reload_features()
+            assert f.is_agent_enabled() is True
+
+    def test_no_disables(self):
+        with patch.dict(os.environ, {"ENABLE_AGENTS": "no"}):
+            f = _reload_features()
+            assert f.is_agent_enabled() is False


### PR DESCRIPTION
## Summary

- Adds `backend/features.py` with `is_finance_gpt_enabled()` and `is_agent_enabled()` helpers
- Gates FinanceGPT imports/startup (`services.finance_gpt`, `chatbot_endpoints`) and agent imports behind their respective flags in `app.py`
- Adds `ENABLE_FINANCE_GPT` and `ENABLE_AGENTS` to `.env.example` (both default to `true`)
- Adds 11 pytest tests covering all flag values (`true`/`false`/`0`/`off`/`no`)

## Test plan
- [ ] `pytest backend/tests/test_features.py -v` → 11 tests pass
- [ ] Deploy with `ENABLE_FINANCE_GPT=false` → FinanceGPT routes not loaded
- [ ] Deploy with `ENABLE_AGENTS=false` → agent classes not imported

Closes #94

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu