### PR TITLE
fix(#88): pin vulnerable dependencies and add npm overrides

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ boto3
 python-dotenv==1.0.0
 flask_mail
 redis
-Werkzeug==2.2.2
+Werkzeug>=3.0.3
 
 # ML/AI
 numpy==1.26.4
@@ -33,7 +33,10 @@ tika==1.24
 PyPDF2==3.0.1
 fpdf==1.7.2
 beautifulsoup4
-requests
+requests>=2.32.0
+urllib3>=2.2.2
+certifi>=2024.7.4
+idna>=3.7
 pandas
 
 # External services
@@ -45,6 +48,8 @@ flask-socketio>=5.3.6
 anthropic
 sec_api
 pycryptodome==3.20.0
+setuptools>=70.0.0
+tqdm>=4.66.3
 
 # Dev / test
 pytest

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "axios": "^1.4.0",
+    "axios": "^1.7.4",
     "copy-to-clipboard": "^3.3.3",
     "flowbite-react": "^0.5.0",
     "react": "^18.2.0",
@@ -54,6 +54,16 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "braces": ">=3.0.3",
+    "micromatch": ">=4.0.8",
+    "postcss": ">=8.4.31",
+    "semver": ">=7.5.4",
+    "word-wrap": ">=1.2.4",
+    "tough-cookie": ">=4.1.3",
+    "nth-check": ">=2.0.1",
+    "axios": ">=1.7.4"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",


### PR DESCRIPTION
## Summary

- Upgrades `Werkzeug` to `>=3.0.3`, `requests` to `>=2.32.0` in `requirements.txt`
- Adds `urllib3>=2.2.2`, `certifi>=2024.7.4`, `idna>=3.7`, `setuptools>=70.0.0`, `tqdm>=4.66.3`
- Bumps `axios` to `^1.7.4` in `frontend/package.json`
- Adds npm `overrides` for transitive deps: braces, micromatch, postcss, semver, word-wrap, tough-cookie, nth-check

## Test plan
- [ ] `pip install -r backend/requirements.txt` succeeds with no conflicts
- [ ] `cd frontend && npm install` resolves without audit errors for patched vulns

Closes #88

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu