### PR TITLE
feat(#158,#162,#74): usage metering, /v1/account, /v1/usage, fix allIds duplicate

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,9 @@ DB_HOST=
 DB_PASSWORD=
 DB_USER=
 
+# Frontend URL for Stripe success/cancel/return redirects (no trailing slash)
+FRONTEND_URL=https://privatechatbot.ai
+
 # Feature flags (set to "false" to disable; default: enabled)
 ENABLE_FINANCE_GPT=true
 ENABLE_AGENTS=true

--- a/backend/api_endpoints/payments/handler.py
+++ b/backend/api_endpoints/payments/handler.py
@@ -1,3 +1,4 @@
+import os
 
 from flask import jsonify
 from database.db import add_subscription, delete_subscription, stripe_subscription_for_user, config_for_payment_tiers, user_has_free_trial, stripe_customer_for_user
@@ -8,6 +9,10 @@ from constants.global_constants import PaidUserStatus
 from database.db import user_has_free_trial, refresh_credits, user_email_for_id, user_email_for_customer_id, no_subscriptions_with_end_date_null
 from database.db_auth import user_id_for_email
 from datetime import datetime
+
+# Allow the frontend URL to be configured via environment variable so the same
+# backend binary can be pointed at different deployments (local, staging, prod).
+_FRONTEND_URL = os.getenv("FRONTEND_URL", "https://privatechatbot.ai").rstrip("/")
 
 
 def CreateCheckoutSessionHandler(request, userEmail):
@@ -52,8 +57,8 @@ def CreateCheckoutSessionHandler(request, userEmail):
                     },
                 ],
                 mode='subscription',
-                success_url="https://privatechatbot.ai/account",
-                cancel_url="https://privatechatbot.ai/account",
+                success_url=f"{_FRONTEND_URL}/account",
+                cancel_url=f"{_FRONTEND_URL}/account",
                 metadata={
                     'user_id': user_id
                 },
@@ -83,7 +88,7 @@ def CreatePortalSessionHandler(request, userEmail):
     if no_subscriptions_with_end_date_null(userEmail):
         return jsonify({'status': "Already canceled."}), 400
 
-    return_url = "https://privatechatbot.ai/account"
+    return_url = f"{_FRONTEND_URL}/account"
     print("return_url")
     config = config_for_payment_tiers(userEmail, request.json["paymentTier"])
     print("config")

--- a/backend/app.py
+++ b/backend/app.py
@@ -1410,6 +1410,153 @@ _SUPPORTED_MODELS = [
 ]
 
 
+@app.route("/v1/account", methods=["GET"])
+@valid_api_key_required
+def v1_account():
+    """Return account, subscription, and credit information for the caller.
+
+    This is an Anote-specific extension to the OpenAI-compatible API surface.
+    The response mirrors the shape returned by ``GET /viewUser`` but lives under
+    the ``/v1/`` namespace so SDK clients can reach it without a separate host.
+
+    Returns 200 with JSON:
+        id            – numeric user ID
+        email         – user email
+        plan          – string plan name (free / basic / standard / premium / enterprise)
+        plan_level    – integer 0-4 (matches PaidUserStatus enum)
+        credits_remaining – integer credits left this period
+        credits_monthly   – integer credits granted per billing period (0 = pay-as-you-go)
+        credits_refresh_date – ISO date of next credit reset, or null
+        subscription_status  – "active" | "trialing" | "canceled" | "none"
+        subscription_end_date – ISO date subscription expires, or null
+        is_free_trial – boolean
+        limits        – object with per-plan quotas
+    """
+    from database.db import view_user
+    from constants.global_constants import planToCredits
+
+    api_key = request.headers.get("Authorization", "").replace("Bearer ", "").strip()
+    user_email = user_email_for_api_key(api_key)
+    result = view_user(user_email)
+
+    # view_user returns a Flask Response — unwrap it
+    if hasattr(result, "get_json"):
+        user_data = result.get_json()
+    elif isinstance(result, tuple):
+        user_data = result[0].get_json() if hasattr(result[0], "get_json") else {}
+    else:
+        user_data = {}
+
+    plan_level = int(user_data.get("paid_user") or 0)
+    plan_names = {0: "free", 1: "basic", 2: "standard", 3: "premium", 4: "enterprise"}
+
+    # Determine subscription status
+    end_date = user_data.get("end_date")
+    is_free_trial = bool(user_data.get("is_free_trial"))
+    if is_free_trial:
+        status = "trialing"
+    elif plan_level > 0:
+        status = "active" if not end_date else "canceled"
+    else:
+        status = "none"
+
+    monthly_credits = planToCredits.get(plan_level, 0)
+
+    return jsonify({
+        "object": "account",
+        "id": user_data.get("id"),
+        "email": user_data.get("email"),
+        "name": user_data.get("name"),
+        "plan": plan_names.get(plan_level, "free"),
+        "plan_level": plan_level,
+        "credits_remaining": user_data.get("credits", 0),
+        "credits_monthly": monthly_credits,
+        "credits_refresh_date": user_data.get("credits_refresh"),
+        "subscription_status": status,
+        "subscription_end_date": end_date,
+        "is_free_trial": is_free_trial,
+        "next_plan": user_data.get("next_plan"),
+        "limits": {
+            "credits_per_month": monthly_credits,
+            "models": _SUPPORTED_MODELS,
+        },
+    })
+
+
+@app.route("/v1/usage", methods=["GET"])
+@valid_api_key_required
+def v1_usage():
+    """Return API usage history and summary for the caller.
+
+    Query parameters:
+        start_date – ISO date string YYYY-MM-DD (optional, inclusive)
+        end_date   – ISO date string YYYY-MM-DD (optional, inclusive)
+        limit      – max rows to return (default 100, max 1000)
+
+    Returns 200 with JSON shaped like::
+
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": 1,
+              "endpoint": "/v1/chat/completions",
+              "model": "gpt-4o",
+              "prompt_tokens": 120,
+              "completion_tokens": 85,
+              "total_tokens": 205,
+              "credits_used": 1,
+              "created": "2024-01-15T10:30:00"
+            },
+            …
+          ],
+          "summary": {
+            "total_requests": 42,
+            "prompt_tokens": 5100,
+            "completion_tokens": 3600,
+            "total_tokens": 8700,
+            "credits_used": 42,
+            "period_start": "2024-01-01",
+            "period_end": "2024-01-31"
+          }
+        }
+    """
+    from database.usage import get_usage_rows, get_usage_summary, user_and_key_ids_for_api_key
+
+    api_key = request.headers.get("Authorization", "").replace("Bearer ", "").strip()
+    user_id, _ = user_and_key_ids_for_api_key(api_key)
+    if user_id is None:
+        return jsonify({"error": "API key not found"}), 401
+
+    start_date = request.args.get("start_date")
+    end_date = request.args.get("end_date")
+    try:
+        limit = int(request.args.get("limit", 100))
+    except (TypeError, ValueError):
+        limit = 100
+
+    rows = get_usage_rows(user_id, start_date=start_date, end_date=end_date, limit=limit)
+    summary = get_usage_summary(user_id, start_date=start_date, end_date=end_date)
+
+    # Serialize datetimes to ISO strings
+    serialized = []
+    for row in rows:
+        r = dict(row)
+        if hasattr(r.get("created"), "isoformat"):
+            r["created"] = r["created"].isoformat()
+        serialized.append(r)
+
+    return jsonify({
+        "object": "list",
+        "data": serialized,
+        "summary": {
+            **summary,
+            "period_start": start_date,
+            "period_end": end_date,
+        },
+    })
+
+
 @app.route("/v1/models", methods=["GET"])
 @valid_api_key_required
 def v1_list_models():
@@ -1482,6 +1629,8 @@ def v1_chat_completions():  # pragma: no cover
     anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
 
     answer = ""
+    prompt_tokens = 0
+    completion_tokens = 0
 
     try:
         if chat_id:
@@ -1512,6 +1661,8 @@ def v1_chat_completions():  # pragma: no cover
                     messages=[{"role": "user", "content": user_message}],
                 )
                 answer = resp.content[0].text
+                prompt_tokens = resp.usage.input_tokens
+                completion_tokens = resp.usage.output_tokens
             else:
                 import openai as _openai
                 _client = _openai.OpenAI(api_key=openai_api_key)
@@ -1523,6 +1674,9 @@ def v1_chat_completions():  # pragma: no cover
                     ],
                 )
                 answer = resp.choices[0].message.content
+                if resp.usage:
+                    prompt_tokens = resp.usage.prompt_tokens
+                    completion_tokens = resp.usage.completion_tokens
 
             message_id = add_message_to_db(answer, chat_id, 0)
             try:
@@ -1563,11 +1717,16 @@ def v1_chat_completions():  # pragma: no cover
                     messages=conv_msgs,
                 )
                 answer = resp.content[0].text
+                prompt_tokens = resp.usage.input_tokens
+                completion_tokens = resp.usage.output_tokens
             else:
                 import openai as _openai
                 _client = _openai.OpenAI(api_key=openai_api_key)
                 resp = _client.chat.completions.create(model=model, messages=formatted)
                 answer = resp.choices[0].message.content
+                if resp.usage:
+                    prompt_tokens = resp.usage.prompt_tokens
+                    completion_tokens = resp.usage.completion_tokens
 
     except Exception as exc:
         return jsonify({
@@ -1577,6 +1736,25 @@ def v1_chat_completions():  # pragma: no cover
                 "code": "internal_error",
             }
         }), 500
+
+    # ------------------------------------------------------------------
+    # Log usage (best-effort — never fails the request)
+    # ------------------------------------------------------------------
+    try:
+        from database.usage import log_api_usage, user_and_key_ids_for_api_key as _uid_kid
+        _raw_key = request.headers.get("Authorization", "").replace("Bearer ", "").strip()
+        _uid, _kid = _uid_kid(_raw_key)
+        log_api_usage(
+            user_id=_uid,
+            api_key_id=_kid,
+            endpoint="/v1/chat/completions",
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            credits_used=1,
+        )
+    except Exception:
+        pass
 
     # ------------------------------------------------------------------
     # Build OpenAI-compatible response envelope
@@ -1598,9 +1776,9 @@ def v1_chat_completions():  # pragma: no cover
             }
         ],
         "usage": {
-            "prompt_tokens": -1,   # not tracked yet
-            "completion_tokens": -1,
-            "total_tokens": -1,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
         },
         # Anote-specific extension fields
         "anote": {

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -212,6 +212,22 @@ CREATE TABLE user_company_chatbots (
     FOREIGN KEY (user_id) REFERENCES users(id)
 );
 
+-- Per-request usage log for billing metering and the /v1/usage API
+CREATE TABLE IF NOT EXISTS api_usage (
+    id          INTEGER PRIMARY KEY AUTO_INCREMENT,
+    user_id     INTEGER,
+    api_key_id  INTEGER,
+    endpoint    VARCHAR(128) NOT NULL,
+    model       VARCHAR(128),
+    prompt_tokens      INTEGER NOT NULL DEFAULT 0,
+    completion_tokens  INTEGER NOT NULL DEFAULT 0,
+    total_tokens       INTEGER NOT NULL DEFAULT 0,
+    credits_used       INTEGER NOT NULL DEFAULT 1,
+    created     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id)    REFERENCES users(id)   ON DELETE SET NULL,
+    FOREIGN KEY (api_key_id) REFERENCES apiKeys(id) ON DELETE SET NULL
+);
+
 
 
 CREATE UNIQUE INDEX idx_users_email ON users(email);
@@ -225,3 +241,6 @@ CREATE INDEX idx_chunks_document_id ON chunks(document_id);
 CREATE INDEX idx_prompt_answers_prompt_id ON prompt_answers(prompt_id);
 CREATE INDEX idx_prompt_answers_citation_id ON prompt_answers(citation_id);
 CREATE UNIQUE INDEX idx_user_chatbot_unique ON user_company_chatbots(user_id, path);
+CREATE INDEX idx_api_usage_user_id  ON api_usage(user_id);
+CREATE INDEX idx_api_usage_key_id   ON api_usage(api_key_id);
+CREATE INDEX idx_api_usage_created  ON api_usage(created);

--- a/backend/database/usage.py
+++ b/backend/database/usage.py
@@ -1,0 +1,162 @@
+"""
+Usage metering helpers — log per-request API usage and query history.
+
+All functions use the shared connection pool from database.db_pool.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from database.db_pool import get_db_connection
+
+
+def log_api_usage(
+    *,
+    user_id: int | None,
+    api_key_id: int | None,
+    endpoint: str,
+    model: str | None,
+    prompt_tokens: int,
+    completion_tokens: int,
+    credits_used: int = 1,
+) -> None:
+    """Insert one row into ``api_usage``.  Never raises — failures are swallowed
+    so that a logging error never breaks a user-facing request."""
+    try:
+        conn, cursor = get_db_connection()
+        total = prompt_tokens + completion_tokens
+        cursor.execute(
+            """
+            INSERT INTO api_usage
+                (user_id, api_key_id, endpoint, model,
+                 prompt_tokens, completion_tokens, total_tokens, credits_used)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            [user_id, api_key_id, endpoint, model,
+             prompt_tokens, completion_tokens, total, credits_used],
+        )
+        conn.commit()
+    except Exception as exc:  # noqa: BLE001
+        print(f"[usage] log_api_usage failed: {exc}")
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def get_usage_rows(
+    user_id: int,
+    *,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return individual usage rows for a user, newest-first.
+
+    ``start_date`` / ``end_date`` are optional ISO-8601 date strings (``YYYY-MM-DD``).
+    """
+    conn, cursor = get_db_connection()
+    try:
+        params: list[Any] = [user_id]
+        clauses = ["user_id = %s"]
+
+        if start_date:
+            clauses.append("created >= %s")
+            params.append(start_date)
+        if end_date:
+            clauses.append("created < DATE_ADD(%s, INTERVAL 1 DAY)")
+            params.append(end_date)
+
+        where = " AND ".join(clauses)
+        params.append(min(limit, 1000))  # hard cap
+
+        cursor.execute(
+            f"""
+            SELECT id, endpoint, model,
+                   prompt_tokens, completion_tokens, total_tokens,
+                   credits_used, created
+            FROM api_usage
+            WHERE {where}
+            ORDER BY created DESC
+            LIMIT %s
+            """,
+            params,
+        )
+        rows = cursor.fetchall()
+        return [dict(r) for r in rows] if rows else []
+    finally:
+        conn.close()
+
+
+def get_usage_summary(
+    user_id: int,
+    *,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> dict[str, Any]:
+    """Return aggregated usage totals for a user over the given period."""
+    conn, cursor = get_db_connection()
+    try:
+        params: list[Any] = [user_id]
+        clauses = ["user_id = %s"]
+
+        if start_date:
+            clauses.append("created >= %s")
+            params.append(start_date)
+        if end_date:
+            clauses.append("created < DATE_ADD(%s, INTERVAL 1 DAY)")
+            params.append(end_date)
+
+        where = " AND ".join(clauses)
+
+        cursor.execute(
+            f"""
+            SELECT
+                COUNT(*)                  AS total_requests,
+                COALESCE(SUM(prompt_tokens),     0) AS prompt_tokens,
+                COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+                COALESCE(SUM(total_tokens),      0) AS total_tokens,
+                COALESCE(SUM(credits_used),      0) AS credits_used
+            FROM api_usage
+            WHERE {where}
+            """,
+            params,
+        )
+        row = cursor.fetchone()
+        if not row:
+            return {
+                "total_requests": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "credits_used": 0,
+            }
+        return {
+            "total_requests": int(row["total_requests"]),
+            "prompt_tokens": int(row["prompt_tokens"]),
+            "completion_tokens": int(row["completion_tokens"]),
+            "total_tokens": int(row["total_tokens"]),
+            "credits_used": int(row["credits_used"]),
+        }
+    finally:
+        conn.close()
+
+
+def user_and_key_ids_for_api_key(api_key: str) -> tuple[int | None, int | None]:
+    """Return ``(user_id, api_key_id)`` for the given raw API key string."""
+    conn, cursor = get_db_connection()
+    try:
+        cursor.execute(
+            "SELECT p.id AS user_id, c.id AS key_id "
+            "FROM users p JOIN apiKeys c ON c.user_id = p.id "
+            "WHERE c.api_key = %s",
+            [api_key],
+        )
+        row = cursor.fetchone()
+        if row:
+            return int(row["user_id"]), int(row["key_id"])
+        return None, None
+    finally:
+        conn.close()

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -1,0 +1,174 @@
+"""Tests for backend/database/usage.py usage-metering helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, call
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_cursor(rows=None, fetchone_return=None):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = rows or []
+    cursor.fetchone.return_value = fetchone_return
+    return cursor
+
+
+def _make_conn(cursor):
+    conn = MagicMock()
+    conn.__enter__ = lambda s: s
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+def _patch_db(cursor, conn=None):
+    """Return a context manager that patches get_db_connection."""
+    if conn is None:
+        conn = _make_conn(cursor)
+    return patch("database.usage.get_db_connection", return_value=(conn, cursor))
+
+
+# ── log_api_usage ─────────────────────────────────────────────────────────────
+
+class TestLogApiUsage:
+    def test_inserts_row_with_correct_total(self):
+        cursor = _make_cursor()
+        conn = _make_conn(cursor)
+        with _patch_db(cursor, conn):
+            from database.usage import log_api_usage
+            log_api_usage(
+                user_id=1,
+                api_key_id=2,
+                endpoint="/v1/chat/completions",
+                model="gpt-4o",
+                prompt_tokens=100,
+                completion_tokens=50,
+                credits_used=1,
+            )
+        cursor.execute.assert_called_once()
+        sql, params = cursor.execute.call_args[0]
+        assert "INSERT INTO api_usage" in sql
+        assert 150 in params  # total_tokens = 100 + 50
+        conn.commit.assert_called_once()
+
+    def test_swallows_db_errors(self):
+        """log_api_usage must never propagate exceptions."""
+        with patch("database.usage.get_db_connection", side_effect=RuntimeError("db down")):
+            from database.usage import log_api_usage
+            # Should not raise
+            log_api_usage(
+                user_id=None,
+                api_key_id=None,
+                endpoint="/v1/chat/completions",
+                model="gpt-4o",
+                prompt_tokens=0,
+                completion_tokens=0,
+            )
+
+    def test_handles_none_user_and_key(self):
+        cursor = _make_cursor()
+        conn = _make_conn(cursor)
+        with _patch_db(cursor, conn):
+            from database.usage import log_api_usage
+            log_api_usage(
+                user_id=None,
+                api_key_id=None,
+                endpoint="/v1/question-answer",
+                model=None,
+                prompt_tokens=0,
+                completion_tokens=0,
+            )
+        _, params = cursor.execute.call_args[0]
+        assert params[0] is None  # user_id
+        assert params[1] is None  # api_key_id
+
+
+# ── get_usage_rows ─────────────────────────────────────────────────────────────
+
+class TestGetUsageRows:
+    def test_returns_rows_as_dicts(self):
+        fake_row = {
+            "id": 1, "endpoint": "/v1/chat/completions", "model": "gpt-4o",
+            "prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150,
+            "credits_used": 1, "created": "2024-01-15 10:00:00",
+        }
+        cursor = _make_cursor(rows=[fake_row])
+        with _patch_db(cursor):
+            from database.usage import get_usage_rows
+            result = get_usage_rows(user_id=1)
+        assert len(result) == 1
+        assert result[0]["model"] == "gpt-4o"
+        assert result[0]["total_tokens"] == 150
+
+    def test_passes_date_filters_to_query(self):
+        cursor = _make_cursor(rows=[])
+        with _patch_db(cursor):
+            from database.usage import get_usage_rows
+            get_usage_rows(user_id=5, start_date="2024-01-01", end_date="2024-01-31")
+        sql, params = cursor.execute.call_args[0]
+        assert "created >=" in sql
+        assert "DATE_ADD" in sql
+        assert "2024-01-01" in params
+        assert "2024-01-31" in params
+
+    def test_caps_limit_at_1000(self):
+        cursor = _make_cursor(rows=[])
+        with _patch_db(cursor):
+            from database.usage import get_usage_rows
+            get_usage_rows(user_id=1, limit=99999)
+        _, params = cursor.execute.call_args[0]
+        assert 1000 in params
+
+    def test_returns_empty_list_when_no_rows(self):
+        cursor = _make_cursor(rows=[])
+        with _patch_db(cursor):
+            from database.usage import get_usage_rows
+            result = get_usage_rows(user_id=99)
+        assert result == []
+
+
+# ── get_usage_summary ──────────────────────────────────────────────────────────
+
+class TestGetUsageSummary:
+    def test_returns_aggregated_totals(self):
+        fake_summary = {
+            "total_requests": 10,
+            "prompt_tokens": 800,
+            "completion_tokens": 400,
+            "total_tokens": 1200,
+            "credits_used": 10,
+        }
+        cursor = _make_cursor(fetchone_return=fake_summary)
+        with _patch_db(cursor):
+            from database.usage import get_usage_summary
+            result = get_usage_summary(user_id=1)
+        assert result["total_requests"] == 10
+        assert result["total_tokens"] == 1200
+
+    def test_returns_zeros_when_no_data(self):
+        cursor = _make_cursor(fetchone_return=None)
+        with _patch_db(cursor):
+            from database.usage import get_usage_summary
+            result = get_usage_summary(user_id=99)
+        assert result["total_requests"] == 0
+        assert result["credits_used"] == 0
+
+
+# ── user_and_key_ids_for_api_key ───────────────────────────────────────────────
+
+class TestUserAndKeyIdsForApiKey:
+    def test_returns_ids_when_key_found(self):
+        cursor = _make_cursor(fetchone_return={"user_id": 7, "key_id": 3})
+        with _patch_db(cursor):
+            from database.usage import user_and_key_ids_for_api_key
+            uid, kid = user_and_key_ids_for_api_key("test-key-abc")
+        assert uid == 7
+        assert kid == 3
+
+    def test_returns_nones_when_key_not_found(self):
+        cursor = _make_cursor(fetchone_return=None)
+        with _patch_db(cursor):
+            from database.usage import user_and_key_ids_for_api_key
+            uid, kid = user_and_key_ids_for_api_key("nonexistent-key")
+        assert uid is None
+        assert kid is None

--- a/frontend/src/redux/UserSlice.js
+++ b/frontend/src/redux/UserSlice.js
@@ -393,8 +393,12 @@ export const userSlice = createSlice({
       .addCase(generateAPIKey.fulfilled, (state, action) => {
         ensureApiKeysState(state);
         var payload = action.payload;
-        state.entities.apiKeys.allIds.push(payload["id"]);
-        state.entities.apiKeys.byId[payload["id"]] = payload;
+        var id = payload["id"];
+        // Guard against duplicate IDs (e.g. double-dispatch or stale persisted state)
+        if (!state.entities.apiKeys.allIds.includes(id)) {
+          state.entities.apiKeys.allIds.push(id);
+        }
+        state.entities.apiKeys.byId[id] = payload;
       })
       .addCase(deleteAPIKey.fulfilled, (state, action) => {
         ensureApiKeysState(state);

--- a/frontend/src/redux/UserSlice.test.js
+++ b/frontend/src/redux/UserSlice.test.js
@@ -115,4 +115,22 @@ describe("UserSlice API key state", () => {
     expect(nextState.entities.apiKeys.allIds).toEqual([]);
     expect(nextState.entities.apiKeys.byId).toEqual({});
   });
+
+  it("generateAPIKey.fulfilled does not add duplicate id to allIds (#74)", () => {
+    // Simulate the reducer being called twice with the same key (double-dispatch /
+    // stale redux-persist rehydration scenario that caused issue #74)
+    const key = { id: 5, key: "sk-abc", name: "My Key" };
+
+    const after1 = userSlice.reducer(
+      initialState,
+      generateAPIKey.fulfilled(key, "req-1")
+    );
+    const after2 = userSlice.reducer(
+      after1,
+      generateAPIKey.fulfilled(key, "req-2")
+    );
+
+    expect(after2.entities.apiKeys.allIds).toEqual([5]);
+    expect(after2.entities.apiKeys.byId[5]).toEqual(key);
+  });
 });


### PR DESCRIPTION
## Summary

### Usage metering (#158)
- Adds `api_usage` table to `schema.sql` — tracks `endpoint`, `model`, `prompt_tokens`, `completion_tokens`, `total_tokens`, `credits_used`, and `created` per API call
- Adds `backend/database/usage.py`: `log_api_usage()`, `get_usage_rows()`, `get_usage_summary()`, `user_and_key_ids_for_api_key()`
- `/v1/chat/completions` now reads real token counts from OpenAI/Anthropic responses (replaces the `-1` placeholder) and logs each call to `api_usage` after completion

### New billing API endpoints (#162)
- **`GET /v1/account`** — returns subscription status, plan name + level, credits remaining, monthly credit quota, next refresh date, and per-plan limits; all in one call
- **`GET /v1/usage`** — returns paginated per-request usage log + aggregated summary; accepts `start_date`, `end_date`, `limit` query params

### Config fix
- Replace hardcoded `privatechatbot.ai` URLs in `payments/handler.py` with `FRONTEND_URL` env var (defaults to existing value); add to `.env.example`

### Fix #74 — API keys allIds duplicate
- Guard `generateAPIKey.fulfilled` reducer with `includes()` check so double-dispatching the same key never inserts a duplicate ID into `allIds`
- Add regression test that reproduces the double-dispatch scenario

## Test plan
- [ ] `pytest backend/tests/test_usage.py -v` → 11 tests pass
- [ ] `cd frontend && npx vitest run` → 53 tests pass
- [ ] `GET /v1/account` with valid API key returns subscription + credits JSON
- [ ] `GET /v1/usage` returns empty `data: []` for a new key, populated after a chat completion
- [ ] `/v1/chat/completions` response `usage.total_tokens` > 0 (not -1)
- [ ] Deploy with `FRONTEND_URL=http://localhost:3000` → Stripe redirects go to localhost

Closes #74, contributes to #158 and #162

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu