### PR TITLE
security: remove hardcoded live Stripe key, Gmail password, and JWT secret

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,18 @@ DB_HOST=
 DB_PASSWORD=
 DB_USER=
 
+# Flask / JWT — REQUIRED in production. Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+FLASK_SECRET_KEY=
+JWT_SECRET_KEY=
+
+# Email (Flask-Mail) — used for password-reset emails
+MAIL_SERVER=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USE_TLS=true
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_DEFAULT_SENDER=
+
 # Frontend URL for Stripe success/cancel/return redirects (no trailing slash)
 FRONTEND_URL=https://privatechatbot.ai
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -167,10 +167,20 @@ config = {
 
 CORS(app, resources={ r'/*': {'origins': config['ORIGINS']}}, supports_credentials=True)
 
-app.secret_key = '6cac159dd02c902f822635ee0a6c3078'
+_flask_secret = os.getenv("FLASK_SECRET_KEY") or os.getenv("JWT_SECRET_KEY", "")
+if not _flask_secret:
+    import warnings
+    warnings.warn(
+        "FLASK_SECRET_KEY / JWT_SECRET_KEY env var is not set. "
+        "Using an insecure default — set this variable before deploying to production.",
+        stacklevel=1,
+    )
+    _flask_secret = "change-me-in-production"
+
+app.secret_key = _flask_secret
 app.config['SESSION_TYPE'] = 'filesystem'
 app.config['SESSION_COOKIE_HTTPONLY'] = False
-app.config["JWT_SECRET_KEY"] = "6cac159dd02c902f822635ee0a6c3078"
+app.config["JWT_SECRET_KEY"] = _flask_secret
 app.config["JWT_REFRESH_TOKEN_EXPIRES"] = kSessionTokenExpirationTime
 app.config["JWT_TOKEN_LOCATION"] = "headers"
 app.config.from_object(__name__)
@@ -178,13 +188,13 @@ app.config.from_object(__name__)
 jwt_manager = JWTManager(app)
 app.jwt_manager = jwt_manager
 
-# Configure Flask-Mail
-app.config['MAIL_SERVER'] = 'smtp.gmail.com'
-app.config['MAIL_PORT'] = 587
-app.config['MAIL_USE_TLS'] = True
-app.config['MAIL_USERNAME'] = 'vidranatan@gmail.com'
-app.config['MAIL_PASSWORD'] = 'fhytlgpsjyzutlnm'
-app.config['MAIL_DEFAULT_SENDER'] = 'vidranatan@gmail.com'
+# Configure Flask-Mail — all values read from environment variables
+app.config['MAIL_SERVER'] = os.getenv('MAIL_SERVER', 'smtp.gmail.com')
+app.config['MAIL_PORT'] = int(os.getenv('MAIL_PORT', '587'))
+app.config['MAIL_USE_TLS'] = os.getenv('MAIL_USE_TLS', 'true').lower() != 'false'
+app.config['MAIL_USERNAME'] = os.getenv('MAIL_USERNAME', '')
+app.config['MAIL_PASSWORD'] = os.getenv('MAIL_PASSWORD', '')
+app.config['MAIL_DEFAULT_SENDER'] = os.getenv('MAIL_DEFAULT_SENDER', os.getenv('MAIL_USERNAME', ''))
 mail = Mail(app)
 
 

--- a/backend/stripe_config/portal_config.py
+++ b/backend/stripe_config/portal_config.py
@@ -1,8 +1,8 @@
 
-
+import os
 import stripe
 
-stripe.api_key = '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'
+stripe.api_key = os.getenv("STRIPE_SECRET_KEY", "")
 
 # cancel_configuration = stripe.billing_portal.Configuration.create(
 #     features={


### PR DESCRIPTION
## ⚠️ CRITICAL SECURITY FIX — Merge immediately

Three sets of live credentials were committed in plain text and need to be rotated NOW regardless of whether this PR is merged.

### What was exposed
| Secret | File | Action required |
|---|---|---|
| Stripe live secret key (`sk_live_51NQsu...`) | `stripe_config/portal_config.py` | **Revoke at dashboard.stripe.com/apikeys** |
| Gmail app password (`fhytlgpsjyzutlnm`) | `backend/app.py` line 186 | **Revoke at myaccount.google.com/apppasswords** |
| Flask/JWT secret key (`6cac159dd02c902f...`) | `backend/app.py` lines 170/173 | **Regenerate — all existing JWTs are compromised** |

### Changes in this PR
- `stripe_config/portal_config.py`: `stripe.api_key` now reads from `STRIPE_SECRET_KEY` env var
- `app.py`: `FLASK_SECRET_KEY` / `JWT_SECRET_KEY` read from env; emits a warning if unset
- `app.py`: All `MAIL_*` config reads from env vars (`MAIL_USERNAME`, `MAIL_PASSWORD`, etc.)
- `.env.example`: Documents all new required variables with a note to generate the secret key

### ⚠️ Git history still contains the old values
The commits `a7794f6` and `8bbed4e` in git history still contain the raw secrets. Consider running `git-filter-repo` to scrub them, or treat the old values as permanently compromised and rotate immediately.

## Test plan
- [ ] Set `STRIPE_SECRET_KEY`, `FLASK_SECRET_KEY`, `MAIL_USERNAME`, `MAIL_PASSWORD` in `.env`
- [ ] `docker compose up` starts cleanly with no warnings about missing keys
- [ ] Stripe checkout flow works end-to-end
- [ ] Password reset email is delivered

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu