### PR TITLE
fix(mypy): add type annotations to test files and fix handler arg-typ…

### DIFF
--- a/backend/api_endpoints/documents/handler.py
+++ b/backend/api_endpoints/documents/handler.py
@@ -79,7 +79,7 @@ _EXT_TO_MIME: dict[str, str] = {
 }
 
 
-def _resolve_mime(file) -> str:
+def _resolve_mime(file: Any) -> str:
     """Return the best-guess MIME type for an uploaded FileStorage object."""
     mime = (file.content_type or "").split(";")[0].strip().lower()
     if mime and mime != "application/octet-stream":
@@ -138,7 +138,7 @@ def IngestDocumentsHandler(
         category = _media_category(mime)
 
         if category == "text":
-            subcategory = _text_subcategory(mime, filename)
+            subcategory = _text_subcategory(mime, filename or "")
 
             if subcategory == "tabular":
                 # Native CSV / Excel parsing — preserves column structure

--- a/backend/tests/test_features.py
+++ b/backend/tests/test_features.py
@@ -1,73 +1,76 @@
 """Tests for backend/features.py feature-flag helpers."""
 
+from __future__ import annotations
+
 import importlib
 import os
+import types
 from unittest.mock import patch
 
 
-def _reload_features():
+def _reload_features() -> types.ModuleType:
     """Re-import the features module so env vars picked up at import time are fresh."""
     import features  # noqa: PLC0415
-    importlib.reload(features)
-    return features
+    result: types.ModuleType = importlib.reload(features)
+    return result
 
 
 class TestIsFinanceGptEnabled:
-    def test_default_is_true(self):
+    def test_default_is_true(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("ENABLE_FINANCE_GPT", None)
             f = _reload_features()
             assert f.is_finance_gpt_enabled() is True
 
-    def test_explicit_true(self):
+    def test_explicit_true(self) -> None:
         with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "true"}):
             f = _reload_features()
             assert f.is_finance_gpt_enabled() is True
 
-    def test_explicit_false_lowercase(self):
+    def test_explicit_false_lowercase(self) -> None:
         with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "false"}):
             f = _reload_features()
             assert f.is_finance_gpt_enabled() is False
 
-    def test_explicit_false_uppercase(self):
+    def test_explicit_false_uppercase(self) -> None:
         with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "FALSE"}):
             f = _reload_features()
             assert f.is_finance_gpt_enabled() is False
 
-    def test_zero_disables(self):
+    def test_zero_disables(self) -> None:
         with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "0"}):
             f = _reload_features()
             assert f.is_finance_gpt_enabled() is False
 
-    def test_off_disables(self):
+    def test_off_disables(self) -> None:
         with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "off"}):
             f = _reload_features()
             assert f.is_finance_gpt_enabled() is False
 
-    def test_one_enables(self):
+    def test_one_enables(self) -> None:
         with patch.dict(os.environ, {"ENABLE_FINANCE_GPT": "1"}):
             f = _reload_features()
             assert f.is_finance_gpt_enabled() is True
 
 
 class TestIsAgentEnabled:
-    def test_default_is_true(self):
+    def test_default_is_true(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("ENABLE_AGENTS", None)
             f = _reload_features()
             assert f.is_agent_enabled() is True
 
-    def test_explicit_false(self):
+    def test_explicit_false(self) -> None:
         with patch.dict(os.environ, {"ENABLE_AGENTS": "false"}):
             f = _reload_features()
             assert f.is_agent_enabled() is False
 
-    def test_explicit_true(self):
+    def test_explicit_true(self) -> None:
         with patch.dict(os.environ, {"ENABLE_AGENTS": "true"}):
             f = _reload_features()
             assert f.is_agent_enabled() is True
 
-    def test_no_disables(self):
+    def test_no_disables(self) -> None:
         with patch.dict(os.environ, {"ENABLE_AGENTS": "no"}):
             f = _reload_features()
             assert f.is_agent_enabled() is False

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -1,4 +1,7 @@
 """Tests for the centralized LLM provider module."""
+
+from __future__ import annotations
+
 import os
 from unittest.mock import MagicMock, patch
 
@@ -13,42 +16,42 @@ from services.llm_provider import (
 )
 
 
-def test_default_models_defined():
+def test_default_models_defined() -> None:
     assert DEFAULT_OPENAI_MODEL == "gpt-4o"
     assert DEFAULT_ANTHROPIC_MODEL == "claude-3-5-haiku-20241022"
 
 
-def test_llm_provider_enum_values():
+def test_llm_provider_enum_values() -> None:
     assert LLMProvider.OPENAI.value == "openai"
     assert LLMProvider.ANTHROPIC.value == "anthropic"
     assert LLMProvider.LOCAL.value == "local"
 
 
-def test_resolve_model_openai():
+def test_resolve_model_openai() -> None:
     assert resolve_model(0) == DEFAULT_OPENAI_MODEL
 
 
-def test_resolve_model_anthropic():
+def test_resolve_model_anthropic() -> None:
     assert resolve_model(1) == DEFAULT_ANTHROPIC_MODEL
 
 
-def test_resolve_model_unknown_defaults_to_openai():
+def test_resolve_model_unknown_defaults_to_openai() -> None:
     assert resolve_model(99) == DEFAULT_OPENAI_MODEL
 
 
-def test_get_openai_client_returns_client():
+def test_get_openai_client_returns_client() -> None:
     with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
         client = get_openai_client()
         assert client is not None
 
 
-def test_get_anthropic_client_returns_client():
+def test_get_anthropic_client_returns_client() -> None:
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
         client = get_anthropic_client()
         assert client is not None
 
 
-def test_get_chat_completion_openai():
+def test_get_chat_completion_openai() -> None:
     mock_resp = MagicMock()
     mock_resp.choices[0].message.content = "Hello!"
 
@@ -65,7 +68,7 @@ def test_get_chat_completion_openai():
         mock_client.chat.completions.create.assert_called_once()
 
 
-def test_get_chat_completion_anthropic():
+def test_get_chat_completion_anthropic() -> None:
     mock_resp = MagicMock()
     mock_resp.content = [MagicMock(text="Bonjour!")]
 
@@ -82,7 +85,7 @@ def test_get_chat_completion_anthropic():
         mock_client.messages.create.assert_called_once()
 
 
-def test_get_chat_completion_strips_system_from_anthropic_messages():
+def test_get_chat_completion_strips_system_from_anthropic_messages() -> None:
     mock_resp = MagicMock()
     mock_resp.content = [MagicMock(text="ok")]
 

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,4 +1,8 @@
 """Tests for SQLAlchemy ORM models."""
+from __future__ import annotations
+
+from typing import Any, Set
+
 from database.models import (
     ApiKey,
     Base,
@@ -11,46 +15,46 @@ from database.models import (
 )
 
 
-def _cols(model):
+def _cols(model: Any) -> Set[str]:
     return {c.name for c in model.__table__.columns}
 
 
-def test_user_columns():
+def test_user_columns() -> None:
     cols = _cols(User)
     assert {"id", "email", "credits", "password_hash", "session_token"}.issubset(cols)
 
 
-def test_chat_columns():
+def test_chat_columns() -> None:
     cols = _cols(Chat)
     assert {"id", "user_id", "model_type", "associated_task"}.issubset(cols)
 
 
-def test_message_columns():
+def test_message_columns() -> None:
     cols = _cols(Message)
     assert {"id", "chat_id", "message_text", "sent_from_user"}.issubset(cols)
 
 
-def test_document_columns():
+def test_document_columns() -> None:
     cols = _cols(Document)
     assert {"id", "chat_id", "document_name", "media_type"}.issubset(cols)
 
 
-def test_chunk_columns():
+def test_chunk_columns() -> None:
     cols = _cols(Chunk)
     assert {"id", "document_id", "start_index", "end_index"}.issubset(cols)
 
 
-def test_api_key_columns():
+def test_api_key_columns() -> None:
     cols = _cols(ApiKey)
     assert {"id", "user_id", "api_key", "key_name"}.issubset(cols)
 
 
-def test_message_attachment_columns():
+def test_message_attachment_columns() -> None:
     cols = _cols(MessageAttachment)
     assert {"id", "message_id", "media_type", "storage_key"}.issubset(cols)
 
 
-def test_relationships_defined():
+def test_relationships_defined() -> None:
     assert hasattr(User, "chats")
     assert hasattr(Chat, "messages")
     assert hasattr(Chat, "documents")
@@ -58,7 +62,7 @@ def test_relationships_defined():
     assert hasattr(Message, "attachments")
 
 
-def test_base_has_all_tables():
+def test_base_has_all_tables() -> None:
     table_names = set(Base.metadata.tables.keys())
     expected = {"users", "chats", "messages", "documents", "chunks", "apiKeys"}
     assert expected.issubset(table_names)

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -1,5 +1,10 @@
 """Tests for Pydantic request validation schemas."""
+
+from __future__ import annotations
+
 import pytest
+from pydantic import ValidationError
+
 from api_endpoints.schemas import (
     ChatCompletionsRequest,
     ChatMessageSchema,
@@ -8,33 +13,32 @@ from api_endpoints.schemas import (
     PublicChatRequest,
     QuestionAnswerRequest,
 )
-from pydantic import ValidationError
 
 # ---------------------------------------------------------------------------
 # ChatMessageSchema
 # ---------------------------------------------------------------------------
 
-def test_chat_message_str_content():
+def test_chat_message_str_content() -> None:
     msg = ChatMessageSchema(role="user", content="Hello")
     assert msg.role == "user"
     assert msg.content == "Hello"
 
 
-def test_chat_message_list_content():
+def test_chat_message_list_content() -> None:
     msg = ChatMessageSchema(role="user", content=[{"type": "text", "text": "Hi"}])
     assert isinstance(msg.content, list)
 
 
-def test_chat_message_missing_role():
+def test_chat_message_missing_role() -> None:
     with pytest.raises(ValidationError):
-        ChatMessageSchema(content="Hello")  # type: ignore[call-arg]
+        ChatMessageSchema(content="Hello")
 
 
 # ---------------------------------------------------------------------------
 # ChatCompletionsRequest
 # ---------------------------------------------------------------------------
 
-def test_chat_completions_valid():
+def test_chat_completions_valid() -> None:
     req = ChatCompletionsRequest(
         model="gpt-4o",
         messages=[{"role": "user", "content": "Hello"}],
@@ -45,12 +49,12 @@ def test_chat_completions_valid():
     assert req.stream is False
 
 
-def test_chat_completions_default_model():
+def test_chat_completions_default_model() -> None:
     req = ChatCompletionsRequest(messages=[{"role": "user", "content": "Hi"}])
     assert req.model == "gpt-4o"
 
 
-def test_chat_completions_with_chat_id():
+def test_chat_completions_with_chat_id() -> None:
     req = ChatCompletionsRequest(
         messages=[{"role": "user", "content": "Q"}],
         chat_id=42,
@@ -58,48 +62,48 @@ def test_chat_completions_with_chat_id():
     assert req.chat_id == 42
 
 
-def test_chat_completions_missing_messages():
+def test_chat_completions_missing_messages() -> None:
     with pytest.raises(ValidationError):
-        ChatCompletionsRequest(model="gpt-4o")  # type: ignore[call-arg]
+        ChatCompletionsRequest(model="gpt-4o")
 
 
-def test_chat_completions_wrong_type_messages():
+def test_chat_completions_wrong_type_messages() -> None:
     with pytest.raises(ValidationError):
-        ChatCompletionsRequest(model="gpt-4o", messages="not-a-list")  # type: ignore[arg-type]
+        ChatCompletionsRequest(model="gpt-4o", messages="not-a-list")
 
 
 # ---------------------------------------------------------------------------
 # PublicChatRequest
 # ---------------------------------------------------------------------------
 
-def test_public_chat_valid():
+def test_public_chat_valid() -> None:
     req = PublicChatRequest(message="Hello", chat_id=1)
     assert req.message == "Hello"
     assert req.chat_id == 1
     assert req.model_key is None
 
 
-def test_public_chat_missing_message():
+def test_public_chat_missing_message() -> None:
     with pytest.raises(ValidationError):
-        PublicChatRequest(chat_id=1)  # type: ignore[call-arg]
+        PublicChatRequest(chat_id=1)
 
 
-def test_public_chat_missing_chat_id():
+def test_public_chat_missing_chat_id() -> None:
     with pytest.raises(ValidationError):
-        PublicChatRequest(message="Hello")  # type: ignore[call-arg]
+        PublicChatRequest(message="Hello")
 
 
 # ---------------------------------------------------------------------------
 # QuestionAnswerRequest
 # ---------------------------------------------------------------------------
 
-def test_qa_valid():
+def test_qa_valid() -> None:
     req = QuestionAnswerRequest(question="What is this?", chat_id=5)
     assert req.question == "What is this?"
     assert req.model == "gpt-4o"
 
 
-def test_qa_custom_model():
+def test_qa_custom_model() -> None:
     req = QuestionAnswerRequest(question="Q?", chat_id=1, model="claude-3-5-haiku-20241022")
     assert req.model == "claude-3-5-haiku-20241022"
 
@@ -108,26 +112,26 @@ def test_qa_custom_model():
 # EvaluateRequest
 # ---------------------------------------------------------------------------
 
-def test_evaluate_valid():
+def test_evaluate_valid() -> None:
     req = EvaluateRequest(message_id=99)
     assert req.message_id == 99
 
 
-def test_evaluate_missing_message_id():
+def test_evaluate_missing_message_id() -> None:
     with pytest.raises(ValidationError):
-        EvaluateRequest()  # type: ignore[call-arg]
+        EvaluateRequest()
 
 
 # ---------------------------------------------------------------------------
 # CreateChatRequest
 # ---------------------------------------------------------------------------
 
-def test_create_chat_defaults():
+def test_create_chat_defaults() -> None:
     req = CreateChatRequest()
     assert req.chat_type == 0
     assert req.model_type == 0
 
 
-def test_create_chat_custom():
+def test_create_chat_custom() -> None:
     req = CreateChatRequest(chat_type=1, model_type=1)
     assert req.chat_type == 1

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -2,25 +2,30 @@
 
 from __future__ import annotations
 
+from typing import Any, Optional
 from unittest.mock import MagicMock, patch
+
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
-def _make_cursor(rows=None, fetchone_return=None):
+def _make_cursor(
+    rows: Optional[list[Any]] = None,
+    fetchone_return: Optional[Any] = None,
+) -> MagicMock:
     cursor = MagicMock()
     cursor.fetchall.return_value = rows or []
     cursor.fetchone.return_value = fetchone_return
     return cursor
 
 
-def _make_conn(cursor):
+def _make_conn(cursor: MagicMock) -> MagicMock:
     conn = MagicMock()
     conn.__enter__ = lambda s: s
     conn.__exit__ = MagicMock(return_value=False)
     return conn
 
 
-def _patch_db(cursor, conn=None):
+def _patch_db(cursor: MagicMock, conn: Optional[MagicMock] = None) -> Any:
     """Return a context manager that patches get_db_connection."""
     if conn is None:
         conn = _make_conn(cursor)
@@ -30,7 +35,7 @@ def _patch_db(cursor, conn=None):
 # ── log_api_usage ─────────────────────────────────────────────────────────────
 
 class TestLogApiUsage:
-    def test_inserts_row_with_correct_total(self):
+    def test_inserts_row_with_correct_total(self) -> None:
         cursor = _make_cursor()
         conn = _make_conn(cursor)
         with _patch_db(cursor, conn):
@@ -50,7 +55,7 @@ class TestLogApiUsage:
         assert 150 in params  # total_tokens = 100 + 50
         conn.commit.assert_called_once()
 
-    def test_swallows_db_errors(self):
+    def test_swallows_db_errors(self) -> None:
         """log_api_usage must never propagate exceptions."""
         with patch("database.usage.get_db_connection", side_effect=RuntimeError("db down")):
             from database.usage import log_api_usage
@@ -64,7 +69,7 @@ class TestLogApiUsage:
                 completion_tokens=0,
             )
 
-    def test_handles_none_user_and_key(self):
+    def test_handles_none_user_and_key(self) -> None:
         cursor = _make_cursor()
         conn = _make_conn(cursor)
         with _patch_db(cursor, conn):
@@ -85,7 +90,7 @@ class TestLogApiUsage:
 # ── get_usage_rows ─────────────────────────────────────────────────────────────
 
 class TestGetUsageRows:
-    def test_returns_rows_as_dicts(self):
+    def test_returns_rows_as_dicts(self) -> None:
         fake_row = {
             "id": 1, "endpoint": "/v1/chat/completions", "model": "gpt-4o",
             "prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150,
@@ -99,7 +104,7 @@ class TestGetUsageRows:
         assert result[0]["model"] == "gpt-4o"
         assert result[0]["total_tokens"] == 150
 
-    def test_passes_date_filters_to_query(self):
+    def test_passes_date_filters_to_query(self) -> None:
         cursor = _make_cursor(rows=[])
         with _patch_db(cursor):
             from database.usage import get_usage_rows
@@ -110,7 +115,7 @@ class TestGetUsageRows:
         assert "2024-01-01" in params
         assert "2024-01-31" in params
 
-    def test_caps_limit_at_1000(self):
+    def test_caps_limit_at_1000(self) -> None:
         cursor = _make_cursor(rows=[])
         with _patch_db(cursor):
             from database.usage import get_usage_rows
@@ -118,7 +123,7 @@ class TestGetUsageRows:
         _, params = cursor.execute.call_args[0]
         assert 1000 in params
 
-    def test_returns_empty_list_when_no_rows(self):
+    def test_returns_empty_list_when_no_rows(self) -> None:
         cursor = _make_cursor(rows=[])
         with _patch_db(cursor):
             from database.usage import get_usage_rows
@@ -129,7 +134,7 @@ class TestGetUsageRows:
 # ── get_usage_summary ──────────────────────────────────────────────────────────
 
 class TestGetUsageSummary:
-    def test_returns_aggregated_totals(self):
+    def test_returns_aggregated_totals(self) -> None:
         fake_summary = {
             "total_requests": 10,
             "prompt_tokens": 800,
@@ -144,7 +149,7 @@ class TestGetUsageSummary:
         assert result["total_requests"] == 10
         assert result["total_tokens"] == 1200
 
-    def test_returns_zeros_when_no_data(self):
+    def test_returns_zeros_when_no_data(self) -> None:
         cursor = _make_cursor(fetchone_return=None)
         with _patch_db(cursor):
             from database.usage import get_usage_summary
@@ -156,7 +161,7 @@ class TestGetUsageSummary:
 # ── user_and_key_ids_for_api_key ───────────────────────────────────────────────
 
 class TestUserAndKeyIdsForApiKey:
-    def test_returns_ids_when_key_found(self):
+    def test_returns_ids_when_key_found(self) -> None:
         cursor = _make_cursor(fetchone_return={"user_id": 7, "key_id": 3})
         with _patch_db(cursor):
             from database.usage import user_and_key_ids_for_api_key
@@ -164,7 +169,7 @@ class TestUserAndKeyIdsForApiKey:
         assert uid == 7
         assert kid == 3
 
-    def test_returns_nones_when_key_not_found(self):
+    def test_returns_nones_when_key_not_found(self) -> None:
         cursor = _make_cursor(fetchone_return=None)
         with _patch_db(cursor):
             from database.usage import user_and_key_ids_for_api_key


### PR DESCRIPTION
…e error

test_models.py: annotate _cols(Any) -> Set[str], add -> None to all tests test_usage.py: annotate _make_cursor/_make_conn/_patch_db helpers, add -> None
  to all test methods
test_llm_provider.py: add -> None return annotations to all test functions,
  fix import ordering (from __future__ first)
test_features.py: annotate _reload_features() -> types.ModuleType using an
  explicit variable annotation to satisfy mypy without redundant cast
test_schemas.py: add -> None to all test functions, remove stale
  type: ignore[call-arg/arg-type] comments (unused under --follow-imports=skip)
documents/handler.py: annotate _resolve_mime(file: Any), pass filename or ""
  to _text_subcategory to fix str | None vs str arg-type mismatch

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu