### PR TITLE
fix(ruff): modernise type annotations in test files

### DIFF
--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,7 +1,7 @@
 """Tests for SQLAlchemy ORM models."""
 from __future__ import annotations
 
-from typing import Any, Set
+from typing import Any
 
 from database.models import (
     ApiKey,
@@ -15,7 +15,7 @@ from database.models import (
 )
 
 
-def _cols(model: Any) -> Set[str]:
+def _cols(model: Any) -> set[str]:
     return {c.name for c in model.__table__.columns}
 
 

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
-
 from api_endpoints.schemas import (
     ChatCompletionsRequest,
     ChatMessageSchema,
@@ -13,6 +11,7 @@ from api_endpoints.schemas import (
     PublicChatRequest,
     QuestionAnswerRequest,
 )
+from pydantic import ValidationError
 
 # ---------------------------------------------------------------------------
 # ChatMessageSchema

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import MagicMock, patch
-
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 def _make_cursor(
-    rows: Optional[list[Any]] = None,
-    fetchone_return: Optional[Any] = None,
+    rows: list[Any] | None = None,
+    fetchone_return: Any | None = None,
 ) -> MagicMock:
     cursor = MagicMock()
     cursor.fetchall.return_value = rows or []
@@ -25,7 +24,7 @@ def _make_conn(cursor: MagicMock) -> MagicMock:
     return conn
 
 
-def _patch_db(cursor: MagicMock, conn: Optional[MagicMock] = None) -> Any:
+def _patch_db(cursor: MagicMock, conn: MagicMock | None = None) -> Any:
     """Return a context manager that patches get_db_connection."""
     if conn is None:
         conn = _make_conn(cursor)


### PR DESCRIPTION
- test_models.py: replace deprecated typing.Set with built-in set (UP006/UP035)
- test_usage.py: replace Optional[X] with X | None (UP045), fix import order (I001)
- test_schemas.py: fix import block ordering (I001)

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu