### PR TITLE
fix(mypy): wrap delete_chat return in jsonify

### DIFF
--- a/backend/api_endpoints/chat/handler.py
+++ b/backend/api_endpoints/chat/handler.py
@@ -42,7 +42,7 @@ def UpdateChatNameHandler(request: Request, user_email: str) -> ResponseReturnVa
 
 def DeleteChatHandler(request: Request, user_email: str) -> ResponseReturnValue:
     payload = cast(dict[str, Any], request.get_json(force=True))
-    return delete_chat(payload.get("chat_id"), user_email)
+    return jsonify({"message": delete_chat(payload.get("chat_id"), user_email)})
 
 
 def FindMostRecentChatHandler(user_email: str) -> ResponseReturnValue:


### PR DESCRIPTION
## Summary
- `DeleteChatHandler` was returning the raw `str` from `delete_chat()` directly, which mypy correctly flags as `no-any-return` since `ResponseReturnValue` expects a proper Flask response type
- Wrapped the return value in `jsonify({"message": ...})` to satisfy the declared return type

## Test plan
- [ ] `mypy --explicit-package-bases backend/tests backend/api_endpoints/chat/handler.py backend/api_endpoints/documents/handler.py backend/app_helpers.py` reports 0 errors
- [ ] Delete chat still works end-to-end (response body is now `{"message": "Successfully deleted"}` instead of a bare string)

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu