### PR TITLE
fix: import get_openai_client in app.py (fixes NameError in all tests)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -101,6 +101,7 @@ from tika import parser as p
 from datetime import datetime
 
 from features import is_finance_gpt_enabled, is_agent_enabled
+from services.llm_provider import get_openai_client
 from agents.config import AgentConfig
 from api_endpoints.languages.arabic import arabic_blueprint
 from api_endpoints.languages.chinese import chinese_blueprint


### PR DESCRIPTION
## Summary
- `app.py` called `get_openai_client()` at module level but never imported it, causing a `NameError` that prevented `app` from being imported at all
- This broke every test in `test_routes.py` and `test_handlers.py` (74 errors)
- Fix: add `from services.llm_provider import get_openai_client` to the imports

## Root cause
The function was added to `services/llm_provider.py` when the LLM provider was centralised, but the corresponding import in `app.py` was missed.

## Test plan
- [ ] `NameError: name 'get_openai_client' is not defined` no longer appears in test output
- [ ] `test_routes.py` and `test_handlers.py` collect and run without import errors

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu