### PR TITLE
fix(tests): add missing conftest stubs to fix ImportError on all tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -103,7 +103,20 @@ def _install_import_stubs() -> None:
     )
     finance_module.get_text_from_url = lambda url: "page text"
     finance_module.retrieve_message_from_db = lambda *args, **kwargs: []
+    finance_module.retrieve_docs_from_db = lambda *args, **kwargs: []
     _register_module("api_endpoints.financeGPT.chatbot_endpoints", finance_module)
+
+    autonomous_agent_module = types.ModuleType("agents.autonomous_agent")
+
+    class FakeAutonomousDocumentAgent:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def process_query(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {"answer": "autonomous answer", "message_id": 1, "sources": []}
+
+    autonomous_agent_module.AutonomousDocumentAgent = FakeAutonomousDocumentAgent
+    _register_module("agents.autonomous_agent", autonomous_agent_module)
 
     reactive_agent_module = types.ModuleType("agents.reactive_agent")
 


### PR DESCRIPTION
## Summary
- `app.py` unconditionally imports `AutonomousDocumentAgent`, which transitively imports `retrieve_docs_from_db` from the `chatbot_endpoints` stub in `conftest.py`
- That attribute was missing from the stub, causing `ImportError: cannot import name 'retrieve_docs_from_db' (unknown location)` on every single test that imports `app`

## Changes
- Add `retrieve_docs_from_db` to the `chatbot_endpoints` stub in `conftest.py`
- Add a `FakeAutonomousDocumentAgent` stub for `agents.autonomous_agent` so the real module (which has a heavy import chain including LangChain, OpenAI, etc.) is never loaded during tests

## Test plan
- [ ] All 74 previously erroring tests in `test_routes.py` and `test_handlers.py` now collect and run without ImportError

https://claude.ai/code/session_01C9mHttiQ4ZAaBbQecVV7uu