### PR TITLE
fix: allow backend startup without local secrets

### DIFF
--- a/backend/agents/reactive_agent.py
+++ b/backend/agents/reactive_agent.py
@@ -1,5 +1,9 @@
-from langchain.agents import AgentExecutor, create_react_agent
-from langchain.tools import BaseTool
+try:
+    from langchain.agents import AgentExecutor, create_react_agent
+except ImportError:
+    from langchain_classic.agents import AgentExecutor, create_react_agent
+
+from langchain_core.tools import BaseTool
 from langchain_core.messages import HumanMessage
 from langchain_core.prompts import PromptTemplate
 from langchain_openai import ChatOpenAI

--- a/backend/api_endpoints/languages/language_chat.py
+++ b/backend/api_endpoints/languages/language_chat.py
@@ -10,7 +10,16 @@ from flask import Blueprint, jsonify, request
 from openai import OpenAI
 from werkzeug.utils import secure_filename
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+client = None
+
+
+def get_client():
+    global client
+
+    if client is None:
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+    return client
 
 
 def extract_text_from_file(file_storage):
@@ -92,7 +101,7 @@ def make_language_blueprint(
 
             full_messages = [{"role": "system", "content": system_prompt}] + messages
 
-            completion = client.chat.completions.create(
+            completion = get_client().chat.completions.create(
                 model=model_name,
                 messages=full_messages,
             )

--- a/backend/app.py
+++ b/backend/app.py
@@ -334,13 +334,14 @@ os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"  #this is to set our environment
 GOOGLE_CLIENT_ID = "261908856206-fff63nag7j793tkbapd3hugthbcp8kfn.apps.googleusercontent.com"  #enter your client id you got from Google console
 client_secrets_file = os.path.join(pathlib.Path(__file__).parent, "client_secret.json")  #set the path to where the .json file you got Google console is
 
-flow = Flow.from_client_secrets_file(  #Flow is OAuth 2.0 a class that stores all the information on how we want to authorize our users
-    client_secrets_file=client_secrets_file,
-    # scopes=["https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/gmail.send", "openid"],  #here we are specifing what do we get after the authorization
-    scopes=["https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email", "openid"],  #here we are specifing what do we get after the authorization
-    # redirect_uri="http://localhost:5000/callback"  #and the redirect URI is the point where the user will end up after the authorization
-    # redirect_uri="http://127.0.0.1:3000"  #and the redirect URI is the point where the user will end up after the authorization
-)
+def get_oauth_flow():
+    return Flow.from_client_secrets_file(  #Flow is OAuth 2.0 a class that stores all the information on how we want to authorize our users
+        client_secrets_file=client_secrets_file,
+        # scopes=["https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/gmail.send", "openid"],  #here we are specifing what do we get after the authorization
+        scopes=["https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email", "openid"],  #here we are specifing what do we get after the authorization
+        # redirect_uri="http://localhost:5000/callback"  #and the redirect URI is the point where the user will end up after the authorization
+        # redirect_uri="http://127.0.0.1:3000"  #and the redirect URI is the point where the user will end up after the authorization
+    )
 # postmessage
 
 @app.route("/login")  #the page where the user can login
@@ -355,6 +356,7 @@ def login():
       if "localhost" in netloc:
         scheme = "http"
 
+      flow = get_oauth_flow()
       flow.redirect_uri = f'{scheme}://{netloc}/callback'
     #   flow.redirect_uri = f'https://upreachapi.upreach.ai/callback'
 
@@ -390,6 +392,7 @@ def callback():
         free_trial_code = decrypted_token.get('free_trial_code', None)
     except jwt.exceptions.InvalidSignatureError:
         abort(500)
+    flow = get_oauth_flow()
     flow.redirect_uri = decrypted_token["redirect_uri"]
     flow.fetch_token(authorization_response=request.url)
 

--- a/backend/services/finance_gpt.py
+++ b/backend/services/finance_gpt.py
@@ -9,7 +9,10 @@ import PyPDF2
 import ray
 import requests
 from dotenv import load_dotenv
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+try:
+    from langchain.text_splitter import RecursiveCharacterTextSplitter
+except ModuleNotFoundError:
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
 from openai import OpenAI
 from tika import parser as p
 
@@ -23,7 +26,8 @@ MAX_CHUNK_SIZE = 1500
 CHUNK_OVERLAP = 200
 
 _embedding_model = None
-_client = OpenAI()
+_client = None
+_client_lock = threading.Lock()
 _model_lock = threading.Lock()
 _splitter_lock = threading.RLock()
 _text_splitters = {}
@@ -88,6 +92,17 @@ def fetch_external_url(web_url: str) -> requests.Response:
     return requests.get(safe_url, timeout=10, allow_redirects=False)
 
 
+def _get_client() -> OpenAI:
+    global _client
+
+    if _client is None:
+        with _client_lock:
+            if _client is None:
+                _client = OpenAI()
+
+    return _client
+
+
 def _get_model():
     global _embedding_model
 
@@ -103,7 +118,7 @@ def _get_model():
                 if isinstance(texts, str):
                     texts = [texts]
 
-                response = _client.embeddings.create(model=EMBEDDING_MODEL, input=texts)
+                response = _get_client().embeddings.create(model=EMBEDDING_MODEL, input=texts)
                 return [item.embedding for item in response.data]
 
             _embedding_model = embed_fn

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -50,7 +50,7 @@ def get_openai_client() -> openai.OpenAI:
     when the variable ``OPENAI_BASE_URL`` is set; otherwise the official
     OpenAI endpoint is used.
     """
-    api_key = os.getenv("OPENAI_API_KEY", "")
+    api_key = os.getenv("OPENAI_API_KEY") or "local-dev-placeholder"
     base_url = os.getenv("OPENAI_BASE_URL", "http://host.docker.internal:11434/v1")
     return openai.OpenAI(api_key=api_key, base_url=base_url)
 

--- a/backend/tests/test_language_chat.py
+++ b/backend/tests/test_language_chat.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from api_endpoints.languages import language_chat
+
+
+def test_language_chat_openai_client_is_lazy(monkeypatch: Any) -> None:
+    created_clients: list[dict[str, Any]] = []
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs: Any) -> None:
+            created_clients.append(kwargs)
+
+    monkeypatch.setattr(language_chat, "client", None)
+    monkeypatch.setattr(language_chat, "OpenAI", FakeOpenAI)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    assert language_chat.client is None
+
+    client = language_chat.get_client()
+
+    assert client is language_chat.client
+    assert created_clients == [{"api_key": "test-key"}]

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -45,6 +45,16 @@ def test_get_openai_client_returns_client() -> None:
         assert client is not None
 
 
+def test_get_openai_client_uses_local_placeholder_without_key() -> None:
+    with patch.dict(os.environ, {}, clear=True), patch("services.llm_provider.openai.OpenAI") as openai_factory:
+        client = get_openai_client()
+        assert client is openai_factory.return_value
+        openai_factory.assert_called_once_with(
+            api_key="local-dev-placeholder",
+            base_url="http://host.docker.internal:11434/v1",
+        )
+
+
 def test_get_anthropic_client_returns_client() -> None:
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
         client = get_anthropic_client()


### PR DESCRIPTION
## Summary
- Fix backend startup in local development when API keys or Google OAuth secrets are not present.
- Add LangChain 1.x-compatible imports for agent and text splitter modules.
- Lazily initialize OpenAI clients and Google OAuth flow so `/health` can run without local secrets.
- Add regression tests for local OpenAI placeholder config and lazy language chat client creation.

## Validation
- Backend Docker health check returns `Healthy`
- Frontend local app returns `200`
- `pytest backend/tests -q` -> `175 passed`
- `ruff check backend/tests backend/api_endpoints/chat/handler.py backend/api_endpoints/documents/handler.py backend/app_helpers.py` -> passed
- `mypy --explicit-package-bases backend/tests backend/api_endpoints/chat/handler.py backend/api_endpoints/documents/handler.py backend/app_helpers.py` -> passed
- `npm run test:ci -- src/redux/UserSlice.test.js` -> `6 passed`
- `npm run build` -> compiled successfully