### PR TITLE
feat: set standards-compliant SSE headers on chat streaming endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -997,7 +997,16 @@ def process_message_pdf():  # pragma: no cover
                     except (TypeError, ValueError) as e:
                         print(f"Error serializing chunk {chunk}: {e}")
 
-            return Response(generate(), status=200)
+            return Response(
+                generate(),
+                status=200,
+                mimetype="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Accel-Buffering": "no",
+                    "Connection": "keep-alive",
+                },
+            )
 
 
             # return jsonify({

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -447,6 +447,29 @@ def test_process_message_pdf_authenticated_agent_stream(client: Any, app_module:
     assert "chunk-1" in response.get_data(as_text=True)
 
 
+def test_process_message_pdf_streaming_sets_sse_headers(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]) -> None:
+    _authenticate(monkeypatch, app_module)
+
+    class StreamingAgent:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def process_query_stream(self, query: str, chat_id: int, user_email: str, **kwargs: Any) -> list[dict[str, str]]:
+            return [{"answer": "chunk-1"}]
+
+    monkeypatch.setattr(app_module.AgentConfig, "is_agent_enabled", staticmethod(lambda: True))
+    monkeypatch.setattr(app_module, "AutonomousDocumentAgent", StreamingAgent)
+    response = client.post(
+        "/process-message-pdf",
+        json={"message": "hello", "chat_id": 1, "model_type": 0, "is_guest": False},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("text/event-stream")
+    assert response.headers["Cache-Control"] == "no-cache"
+    assert response.headers["X-Accel-Buffering"] == "no"
+
+
 def test_process_message_pdf_invalid_token(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]) -> None:
     monkeypatch.setattr(app_module.AgentConfig, "is_agent_enabled", staticmethod(lambda: False))
     _invalidate_token(monkeypatch, app_module)


### PR DESCRIPTION
## Summary

First, backward-compatible step toward #215. The agent-streamed chat response in `process_message_pdf` returned a bare `Response(generate(), status=200)` with no SSE headers — unlike the SSE endpoint at `app.py:2036`, which already sets `mimetype="text/event-stream"`.

Without these headers, reverse proxies (nginx, Cloudflare) may buffer the stream, and the browser cannot treat the response as a native event stream.

## Changes

- `backend/app.py`: set `Content-Type: text/event-stream`, `Cache-Control: no-cache`, and `X-Accel-Buffering: no` on the streaming chat response
- `backend/tests/test_routes.py`: assert the streaming endpoint returns these headers

## Why this is safe

The `data:` payload format is unchanged, so the existing frontend `getReader()` parser (`Chatbot.js:500`) is unaffected. This change is purely additive: no behavior change for clients that already work, and correct SSE semantics for proxies and future `EventSource` consumers.

## Scope

Covers only the first checklist item in #215 (SSE headers). The remaining items — `event:` framing, `tool`/`tool_result` events, `done` event, client-abort detection, and the frontend `EventSource` migration — are follow-ups tracked in that issue.

Part of #215.

## Test plan

- [x] New unit test asserts `Content-Type` / `Cache-Control` / `X-Accel-Buffering` on the streamed response
- [ ] CI green (backend quality gates + tests)
