### PR TITLE
fix(agents): source multi-agent models from config, honor model_key

### DIFF
--- a/backend/agents/multi_agent_system.py
+++ b/backend/agents/multi_agent_system.py
@@ -111,7 +111,7 @@ class BaseSpecializedAgent:
     
     def _initialize_llm(self):
         if self.model_type == 0:  # OpenAI/GPT
-            model_name = self.model_key if self.model_key else "gpt-4"
+            model_name = self.model_key if self.model_key else AgentConfig.OPENAI_TEXT_MODEL
             return ChatOpenAI(
                 model=model_name,
                 temperature=AgentConfig.AGENT_TEMPERATURE,
@@ -119,8 +119,9 @@ class BaseSpecializedAgent:
                 streaming=True
             )
         else:  # Anthropic/Claude
+            model_name = self.model_key if self.model_key else AgentConfig.ANTHROPIC_TEXT_MODEL
             return ChatAnthropic(
-                model="claude-3-sonnet-20240229",
+                model=model_name,
                 temperature=AgentConfig.AGENT_TEMPERATURE,
                 anthropic_api_key=os.getenv("ANTHROPIC_API_KEY"),
                 streaming=True


### PR DESCRIPTION
## What this does
Source the multi-agent system's LLM models from `AgentConfig` (`OPENAI_TEXT_MODEL` / `ANTHROPIC_TEXT_MODEL`) instead of hardcoding `gpt-4` / `claude-3-sonnet-20240229`, and make the Anthropic branch honor `model_key` (it was silently ignored there). Aligns `multi_agent_system.py` with the config-driven pattern `reactive_agent.py` already uses.

## How to test
- CI: Backend Quality Gates (ruff + mypy + pytest).
- Behavior: the frontend always sends `model_key=""`, so both branches fall back to `AgentConfig` defaults; setting `ANTHROPIC_TEXT_MODEL` / `OPENAI_TEXT_MODEL` (or a matching `model_key`) now actually changes the model with no code edit.

## Notes
- `model_key` must match `model_type` (a Claude model name when `model_type=1`). The real frontend sends `""`, and `reactive_agent.py` already has the same contract — no extra validation added, for consistency.
- Does **not** bump the global `AgentConfig` defaults (still `claude-3-5-sonnet-20241022` / `gpt-4o`) — raising those to 4.x is a separate cost/quality call.
- Opened as draft for CI + visibility; scoped as an independent low-risk fix within the 6/9 reasoning-quality direction.