### PR TITLE
feat(config): startup API-key validation + /health/keys (#217)

### DIFF
--- a/backend/agents/config.py
+++ b/backend/agents/config.py
@@ -1,5 +1,8 @@
+import logging
 import os
-from typing import Dict, Any
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
 
 class AgentConfig:
     """Configuration settings for the reactive agent system"""
@@ -91,3 +94,40 @@ class AgentConfig:
     def is_multi_agent_enabled(cls) -> bool:
         """Check if multi-agent system is enabled"""
         return cls.ENABLE_MULTI_AGENT_SYSTEM
+
+    @classmethod
+    def check_api_keys(cls) -> Dict[str, Any]:
+        """Report which required provider API keys are present (non-blocking).
+
+        OPENAI_API_KEY is always required; ANTHROPIC_API_KEY is required when the
+        agent system is configured to use Anthropic (DEFAULT_AGENT_MODEL_TYPE == 1).
+        Only key *names* and presence are reported — never the key values.
+        """
+        required = ["OPENAI_API_KEY"]
+        if cls.DEFAULT_AGENT_MODEL_TYPE == 1:
+            required.append("ANTHROPIC_API_KEY")
+        present = {name: bool(os.getenv(name)) for name in required}
+        missing = [name for name, ok in present.items() if not ok]
+        return {
+            "ok": not missing,
+            "required": required,
+            "present": present,
+            "missing": missing,
+        }
+
+    @classmethod
+    def log_api_key_status(cls) -> Dict[str, Any]:
+        """Log the startup API-key check. Does NOT raise or block startup."""
+        status = cls.check_api_keys()
+        if status["missing"]:
+            logger.warning(
+                "Startup API-key check: missing %s. The backend will still start, "
+                "but agent calls that need these providers will fail at request time.",
+                ", ".join(status["missing"]),
+            )
+        else:
+            logger.info(
+                "Startup API-key check: all required keys present (%s).",
+                ", ".join(status["required"]),
+            )
+        return status

--- a/backend/app.py
+++ b/backend/app.py
@@ -141,6 +141,9 @@ app.register_blueprint(korean_blueprint)
 app.register_blueprint(spanish_blueprint)
 app.register_blueprint(arabic_blueprint)
 
+# Issue #217: surface missing provider API keys at startup (non-blocking).
+AgentConfig.log_api_key_status()
+
 client = get_openai_client()
 def ensure_ray_started():  # pragma: no cover
     if not ray.is_initialized():
@@ -327,6 +330,20 @@ def health_check():
         description: Server is running
     """
     return "Healthy", 200
+
+@app.route('/health/keys', methods=['GET'])
+def health_keys():
+    """
+    API-key readiness check (issue #217).
+    ---
+    tags:
+      - System
+    responses:
+      200:
+        description: Returns an ok flag for required provider API keys. Which keys are missing is intentionally kept out of this public endpoint and logged at startup instead.
+    """
+    # Public endpoint: expose only an ok flag; missing-key details stay in logs.
+    return jsonify({"ok": AgentConfig.check_api_keys()["ok"]}), 200
 
 # Auth
 os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"  #this is to set our environment to https because OAuth 2.0 only supports https environments

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -140,6 +140,8 @@ def _install_import_stubs() -> None:
     agents_config_module = types.ModuleType("agents.config")
 
     class FakeAgentConfig:
+        DEFAULT_AGENT_MODEL_TYPE = 0
+
         @staticmethod
         def is_agent_enabled() -> bool:
             return False
@@ -147,6 +149,19 @@ def _install_import_stubs() -> None:
         @staticmethod
         def should_use_fallback() -> bool:
             return True
+
+        @staticmethod
+        def check_api_keys() -> dict:
+            return {
+                "ok": True,
+                "required": ["OPENAI_API_KEY"],
+                "present": {"OPENAI_API_KEY": True},
+                "missing": [],
+            }
+
+        @staticmethod
+        def log_api_key_status() -> dict:
+            return FakeAgentConfig.check_api_keys()
 
     agents_config_module.AgentConfig = FakeAgentConfig
     _register_module("agents.config", agents_config_module)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -2,9 +2,30 @@
 
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
 from typing import Any
 
-from agents.config import AgentConfig
+
+def _load_real_agent_config() -> Any:
+    """Load the real agents/config.py directly by file path.
+
+    conftest injects a lightweight FakeAgentConfig into sys.modules for
+    `agents.config` so importing app.py does not pull the heavy `agents`
+    package (langchain et al.). These unit tests exercise the *real* key-check
+    logic, so we load config.py by path, bypassing both that stub and the
+    package __init__. config.py only imports the standard library, so loading
+    it standalone is safe.
+    """
+    path = Path(__file__).resolve().parents[1] / "agents" / "config.py"
+    spec = importlib.util.spec_from_file_location("_real_agents_config", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.AgentConfig
+
+
+AgentConfig = _load_real_agent_config()
 
 
 def test_check_api_keys_openai_always_required(monkeypatch: Any) -> None:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,57 @@
+"""Tests for AgentConfig API-key validation (issue #217)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agents.config import AgentConfig
+
+
+def test_check_api_keys_openai_always_required(monkeypatch: Any) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(AgentConfig, "DEFAULT_AGENT_MODEL_TYPE", 0)
+    status = AgentConfig.check_api_keys()
+    assert status["required"] == ["OPENAI_API_KEY"]
+    assert status["ok"] is True
+    assert status["missing"] == []
+
+
+def test_check_api_keys_requires_anthropic_when_model_type_anthropic(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(AgentConfig, "DEFAULT_AGENT_MODEL_TYPE", 1)
+    status = AgentConfig.check_api_keys()
+    assert "ANTHROPIC_API_KEY" in status["required"]
+    assert status["ok"] is False
+    assert status["missing"] == ["ANTHROPIC_API_KEY"]
+
+
+def test_check_api_keys_flags_missing_openai(monkeypatch: Any) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(AgentConfig, "DEFAULT_AGENT_MODEL_TYPE", 0)
+    status = AgentConfig.check_api_keys()
+    assert status["ok"] is False
+    assert "OPENAI_API_KEY" in status["missing"]
+    assert status["present"]["OPENAI_API_KEY"] is False
+
+
+def test_log_api_key_status_does_not_raise_and_returns_status(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(AgentConfig, "DEFAULT_AGENT_MODEL_TYPE", 0)
+    # Non-blocking: logging a missing key must never raise.
+    status = AgentConfig.log_api_key_status()
+    assert status["ok"] is False
+
+
+def test_health_keys_endpoint_exposes_only_ok_flag(client: Any) -> None:
+    # Public endpoint: only an ok flag is exposed; details stay in logs.
+    response = client.get("/health/keys")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert set(data) == {"ok"}
+    assert isinstance(data["ok"], bool)


### PR DESCRIPTION
Implements #217: a non-blocking API-key check at backend startup.

## What this does
- `AgentConfig.check_api_keys()` — reports which required provider keys are present (`OPENAI_API_KEY` always; `ANTHROPIC_API_KEY` when `DEFAULT_AGENT_MODEL_TYPE == 1`). Reports only key **names** and presence — never values.
- `AgentConfig.log_api_key_status()` — logs a clear warning at startup if any key is missing; called once on app import. **Never raises** → startup is not blocked (preserves local dev / CI).
- `GET /health/keys` — returns `{"ok": true|false}`. Public (like `/health`), so it deliberately exposes only the ok flag; the missing-key details stay in the startup logs.

## How to test
- `pytest tests/test_config.py` — 5 tests (4 unit + 1 route).
- Existing `/health` unchanged (still returns "Healthy").

## Notes
- Self-reviewed: `/health/keys` is public, so it returns only an ok flag (not which providers are configured) to avoid leaking backend config topology.
- The startup check validates the default-configured provider; per-request provider overrides aren't validated at boot (matches the issue's "if Anthropic agent is configured").

Closes #217