### PR TITLE
feat(agents): optional model-driven routing for multi-agent decisions (flag-gated)

### DIFF
--- a/backend/agents/config.py
+++ b/backend/agents/config.py
@@ -9,6 +9,9 @@ class AgentConfig:
     AGENT_FALLBACK_ENABLED = os.getenv("AGENT_FALLBACK_ENABLED", "true").lower() == "true"
     ENABLE_GENERAL_KNOWLEDGE = os.getenv("ENABLE_GENERAL_KNOWLEDGE", "true").lower() == "true"
     ENABLE_MULTI_AGENT_SYSTEM = os.getenv("ENABLE_MULTI_AGENT_SYSTEM", "true").lower() == "true"
+    # Route agent branch decisions with the model (reasoning over intent) instead of
+    # keyword matching. Default OFF — opt-in so production behaviour is unchanged.
+    ENABLE_LLM_ROUTING = os.getenv("ENABLE_LLM_ROUTING", "false").lower() == "true"
 
     # MCP Server settings
     MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://localhost:8000")
@@ -56,6 +59,7 @@ class AgentConfig:
             "fallback_enabled": cls.AGENT_FALLBACK_ENABLED,
             "enable_general_knowledge": cls.ENABLE_GENERAL_KNOWLEDGE,
             "enable_multi_agent": cls.ENABLE_MULTI_AGENT_SYSTEM,
+            "enable_llm_routing": cls.ENABLE_LLM_ROUTING,
             "mcp_server_url": cls.MCP_SERVER_URL,
             "mcp_timeout": cls.MCP_SERVER_TIMEOUT,
             "default_model_type": cls.DEFAULT_AGENT_MODEL_TYPE,

--- a/backend/agents/multi_agent_system.py
+++ b/backend/agents/multi_agent_system.py
@@ -1,6 +1,7 @@
 from langgraph.graph import StateGraph, END
 from typing import Dict, List, Any, Optional, Generator, TypedDict
 import json
+import logging
 import time
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
@@ -13,6 +14,10 @@ from api_endpoints.financeGPT.chatbot_endpoints import (
     retrieve_message_from_db, retrieve_docs_from_db
 )
 from .config import AgentConfig
+from .routing import route_boolean
+
+logger = logging.getLogger(__name__)
+
 
 class AgentState(TypedDict):
     """Shared state between all agents in the network"""
@@ -249,7 +254,20 @@ class ChatHistoryAgent(BaseSpecializedAgent):
             
             # Check if query needs historical context
             context_keywords = ["it", "that", "the one", "shorter", "longer", "what I said", "previous", "before", "earlier", "last", "prior", "context", "history", "refer to", "mentioned"]
-            needs_context = any(keyword in query.lower() for keyword in context_keywords)
+            keyword_needs_context = any(keyword in query.lower() for keyword in context_keywords)
+            needs_context, _route_src, _route_reason = route_boolean(
+                self.llm,
+                "Does answering this query require earlier conversation history or context?",
+                query,
+                keyword_needs_context,
+                getattr(AgentConfig, "ENABLE_LLM_ROUTING", False),
+            )
+            if _route_src == "llm" and needs_context != keyword_needs_context:
+                # A/B evidence only — no user content logged (CodeQL/privacy safe).
+                logger.info(
+                    "%s LLM routing override: needs_context keyword=%s model=%s",
+                    self.name, keyword_needs_context, needs_context,
+                )
             
             if not needs_context:
                 reasoning_step = {
@@ -357,7 +375,19 @@ class DocumentListAgent(BaseSpecializedAgent):
             
             # Check if query is asking about available documents
             list_keywords = ["list", "documents", "files", "available", "what documents", "show me", "which documents"]
-            is_list_query = any(keyword in query.lower() for keyword in list_keywords)
+            keyword_is_list_query = any(keyword in query.lower() for keyword in list_keywords)
+            is_list_query, _route_src, _route_reason = route_boolean(
+                self.llm,
+                "Is the user asking to list or show the available documents/files (rather than asking about their contents)?",
+                query,
+                keyword_is_list_query,
+                getattr(AgentConfig, "ENABLE_LLM_ROUTING", False),
+            )
+            if _route_src == "llm" and is_list_query != keyword_is_list_query:
+                logger.info(
+                    "%s LLM routing override: is_list_query keyword=%s model=%s",
+                    self.name, keyword_is_list_query, is_list_query,
+                )
             
             if not is_list_query:
                 reasoning_step = {

--- a/backend/agents/routing.py
+++ b/backend/agents/routing.py
@@ -1,0 +1,99 @@
+"""Model-driven routing helpers for the multi-agent system.
+
+Panacea's agents historically branch on keyword matching (e.g.
+``any(kw in query.lower() for kw in [...])``). Research PR #26
+(Research-OrchestrateBench) measured that this keyword routing fails on
+adversarial phrasings — 0% there — where a model that reasons about intent
+succeeds. These helpers provide an opt-in, model-driven alternative; callers
+fall back to keyword matching whenever routing is disabled or the model call
+fails, so nothing here can break a live query.
+
+Kept dependency-light on purpose (standard library only): the chat model is
+passed in as ``llm``, so this module never imports the heavy agent stack and is
+unit-testable with a fake.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# JSON schema for a single yes/no routing decision. Passed to LangChain's
+# ``with_structured_output`` so the model must return exactly this shape.
+_DECISION_SCHEMA = {
+    "title": "RoutingDecision",
+    "description": "A yes/no routing decision about a user's query.",
+    "type": "object",
+    "properties": {
+        "decision": {
+            "type": "boolean",
+            "description": "True if the answer to the routing question is yes.",
+        },
+        "reasoning": {
+            "type": "string",
+            "description": "One short sentence justifying the decision.",
+        },
+    },
+    "required": ["decision", "reasoning"],
+}
+
+_SYSTEM_PROMPT = (
+    "You are the router for a document Q&A assistant. Answer the yes/no question "
+    "about the user's query by reasoning about its actual intent. Do NOT rely on "
+    "keyword matching — the wording may omit the obvious keywords or use "
+    "misleading ones. Return your answer via the structured schema."
+)
+
+
+def llm_boolean_decision(llm: Any, question: str, query: str) -> bool | None:
+    """Ask ``llm`` a yes/no routing ``question`` about ``query``.
+
+    Returns the boolean decision, or ``None`` if the model path is unavailable or
+    the call/parse fails — callers should fall back to keyword matching on
+    ``None``. Never raises.
+    """
+    try:
+        structured = llm.with_structured_output(_DECISION_SCHEMA)
+        result = structured.invoke(
+            [
+                ("system", _SYSTEM_PROMPT),
+                ("human", f"Question: {question}\nUser query: {query!r}"),
+            ]
+        )
+    except Exception:
+        # Defensive: a routing decision must never crash a live query.
+        return None
+    return _extract_decision(result)
+
+
+def _extract_decision(result: Any) -> bool | None:
+    """Pull a bool ``decision`` out of a structured-output result, defensively."""
+    if isinstance(result, dict):
+        value = result.get("decision")
+    else:  # pydantic model / namespace fallback
+        value = getattr(result, "decision", None)
+    return value if isinstance(value, bool) else None
+
+
+def route_boolean(
+    llm: Any,
+    question: str,
+    query: str,
+    keyword_result: bool,
+    enabled: bool,
+) -> tuple[bool, str, str]:
+    """Resolve a yes/no routing decision, preferring the model when enabled.
+
+    Returns ``(decision, source, reasoning)`` where ``source`` is ``"llm"`` or
+    ``"keyword"``. Falls back to ``keyword_result`` when routing is disabled or the
+    model call fails, so the existing keyword behaviour is always the safety net.
+    """
+    if not enabled:
+        return keyword_result, "keyword", "LLM routing disabled; used keyword match."
+    decision = llm_boolean_decision(llm, question, query)
+    if decision is None:
+        return (
+            keyword_result,
+            "keyword",
+            "LLM routing unavailable; fell back to keyword match.",
+        )
+    return decision, "llm", "Decided by reasoning over the query's intent."

--- a/backend/tests/test_routing.py
+++ b/backend/tests/test_routing.py
@@ -1,0 +1,109 @@
+"""Tests for agents/routing.py — the model-driven routing helpers (issue: 6/9
+reasoning-quality direction; mirrors Research PR #26's measured trade-off)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+
+def _load_routing() -> Any:
+    """Load agents/routing.py directly by file path.
+
+    routing.py imports only the standard library, so loading it standalone avoids
+    the heavy `agents` package __init__ (langchain/langgraph) and lets these tests
+    run with no extra deps, no network, and no API key.
+    """
+    path = Path(__file__).resolve().parents[1] / "agents" / "routing.py"
+    spec = importlib.util.spec_from_file_location("_agents_routing", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+routing = _load_routing()
+
+
+class _FakeStructured:
+    def __init__(self, result: Any, raise_on_invoke: bool = False) -> None:
+        self._result = result
+        self._raise = raise_on_invoke
+
+    def invoke(self, messages: Any) -> Any:
+        if self._raise:
+            raise RuntimeError("model failure")
+        return self._result
+
+
+class _FakeLLM:
+    """Records structured-output usage; returns a preset result on invoke."""
+
+    def __init__(self, result: Any = None, raise_on_invoke: bool = False) -> None:
+        self._result = result
+        self._raise = raise_on_invoke
+        self.structured_calls = 0
+
+    def with_structured_output(self, schema: Any) -> _FakeStructured:
+        self.structured_calls += 1
+        return _FakeStructured(self._result, self._raise)
+
+
+# --- llm_boolean_decision -------------------------------------------------- #
+
+def test_llm_boolean_decision_true() -> None:
+    llm = _FakeLLM(result={"decision": True, "reasoning": "needs context"})
+    assert routing.llm_boolean_decision(llm, "q?", "make the earlier one shorter") is True
+
+
+def test_llm_boolean_decision_false() -> None:
+    llm = _FakeLLM(result={"decision": False, "reasoning": "self-contained"})
+    assert routing.llm_boolean_decision(llm, "q?", "what does EBITDA mean") is False
+
+
+def test_llm_boolean_decision_none_on_bad_shape() -> None:
+    llm = _FakeLLM(result={"reasoning": "no decision field"})
+    assert routing.llm_boolean_decision(llm, "q?", "x") is None
+
+
+def test_llm_boolean_decision_none_on_exception() -> None:
+    llm = _FakeLLM(raise_on_invoke=True)
+    assert routing.llm_boolean_decision(llm, "q?", "x") is None
+
+
+def test_llm_boolean_decision_accepts_object_result() -> None:
+    class _Obj:
+        decision = True
+
+    assert routing.llm_boolean_decision(_FakeLLM(result=_Obj()), "q?", "x") is True
+
+
+# --- route_boolean --------------------------------------------------------- #
+
+def test_route_boolean_disabled_uses_keyword_and_skips_model() -> None:
+    llm = _FakeLLM(result={"decision": True, "reasoning": "x"})
+    decision, source, _ = routing.route_boolean(
+        llm, "q?", "query", keyword_result=False, enabled=False
+    )
+    assert decision is False
+    assert source == "keyword"
+    assert llm.structured_calls == 0  # model never consulted when disabled
+
+
+def test_route_boolean_enabled_uses_model() -> None:
+    llm = _FakeLLM(result={"decision": True, "reasoning": "x"})
+    decision, source, _ = routing.route_boolean(
+        llm, "q?", "query", keyword_result=False, enabled=True
+    )
+    assert decision is True
+    assert source == "llm"
+
+
+def test_route_boolean_falls_back_to_keyword_on_model_failure() -> None:
+    llm = _FakeLLM(raise_on_invoke=True)
+    decision, source, _ = routing.route_boolean(
+        llm, "q?", "query", keyword_result=True, enabled=True
+    )
+    assert decision is True
+    assert source == "keyword"


### PR DESCRIPTION
## What this does
Panacea's multi-agent system (`backend/agents/multi_agent_system.py`) branches on **keyword
matching** — e.g. `needs_context`/`is_list_query` via `any(kw in query.lower() for kw in [...])`.
Research PR #26 (Research-OrchestrateBench) measured that this keyword routing scores **0% on
adversarial phrasings** where a model reasoning over intent scores **100%**.

This PR brings that finding into the product as an **opt-in, model-driven routing path behind a
feature flag** — directly serving the 6/9 product direction (reasoning quality) **without a
rewrite**.

## Approach
- **`agents/routing.py` (new, dependency-light — stdlib only)**: `llm_boolean_decision(llm, ...)`
  uses LangChain `with_structured_output` (the idiomatic equivalent of PR #26's forced tool-use)
  and **returns `None` on any failure**; `route_boolean(...)` prefers the model when enabled and
  **falls back to the keyword result** otherwise. The chat model is passed in, so the module never
  imports the heavy agent stack and is unit-testable with a fake.
- **`agents/config.py`**: `ENABLE_LLM_ROUTING` flag, **default OFF** (+ surfaced in `get_agent_config`).
- **`agents/multi_agent_system.py`**: the two keyword decisions now call `route_boolean(...)`,
  gated by the flag; a CodeQL/privacy-safe `logger.info` records keyword-vs-model **disagreements**
  (no user content logged) for A/B evidence.

## Why it's safe
- **Default OFF → production behavior is byte-identical** until the flag is set.
- Any model failure (or the flag being off) **falls back to the existing keyword path** — a routing
  decision can never crash a live query.
- Opt-in switch for Natan to A/B, not a rewrite (the larger autonomous_agent path + the
  orchestrator's confidence thresholds are explicit follow-ups).

## Testing
- `cd backend && pytest tests/test_routing.py -q` — **8 tests pass** (decision true/false, bad
  shape → None, exception → None, object result; route_boolean disabled-skips-model /
  enabled-uses-model / fallback-on-failure). Tests load `routing.py` by path, so **no langchain,
  network, or API key** is needed.
- Local gate parity: `ruff check` ✅, `mypy --explicit-package-bases backend/tests ...` ✅
  (19 files, clean).

## Follow-ups (not this PR)
- Orchestrator confidence thresholds (`multi_agent_system.py`, `confidence > 0.8`).
- Larger `autonomous_agent.py` reasoning path.
- Default-ON is Natan's call after reviewing the A/B logs.
