### PR TITLE
feat(rsi): qa_feedback foundation — table + flag-gated logging (#220, slice 1)

### DIFF
--- a/backend/alembic/versions/0002_qa_feedback.py
+++ b/backend/alembic/versions/0002_qa_feedback.py
@@ -1,0 +1,47 @@
+"""qa_feedback table for RSI document Q&A (issue #220)
+
+Foundation for the RSI feedback loop: a place to persist implicit/explicit
+feedback signals on Q&A answers so later slices (re-ranker training,
+self-consistency checks) have a training signal. Adding the table is inert on
+its own — nothing writes to it unless ENABLE_RSI_FEEDBACK is set.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-06-14 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS qa_feedback (
+            id INTEGER PRIMARY KEY AUTO_INCREMENT,
+            created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            chat_id INTEGER NOT NULL,
+            message_id INTEGER DEFAULT NULL,
+            question TEXT NOT NULL,
+            retrieved_chunks TEXT,
+            answer TEXT NOT NULL,
+            feedback_signal VARCHAR(32) NOT NULL,
+            session_id VARCHAR(255) DEFAULT NULL,
+            source VARCHAR(16) NOT NULL DEFAULT 'implicit',
+            FOREIGN KEY (chat_id) REFERENCES chats(id)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX idx_qa_feedback_chat_id ON qa_feedback(chat_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS qa_feedback")

--- a/backend/database/qa_feedback.py
+++ b/backend/database/qa_feedback.py
@@ -1,0 +1,95 @@
+"""RSI feedback logging for document Q&A — issue #220 (slice 1: foundation).
+
+Persists implicit/explicit feedback signals on Q&A answers to the `qa_feedback`
+table (migration 0002), so the RSI loop in later slices (re-ranker training,
+answer self-consistency) has a training signal.
+
+Design constraints:
+- **Opt-in**: collection is OFF unless ``ENABLE_RSI_FEEDBACK`` is truthy, so
+  production behaviour is unchanged until enabled.
+- **Best-effort**: a logging failure must never break a chat response — every
+  path is wrapped and returns a bool instead of raising (mirrors
+  ``database/db_auth.py:touch_api_key_last_used``).
+"""
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Sequence
+from typing import Any
+
+from database.db_pool import get_db_connection
+
+# Implicit signals are derived from user behaviour; explicit ones from UI.
+VALID_SIGNALS = frozenset(
+    {
+        "positive",
+        "negative",
+        "followup",  # follow-up question within a short window (implicit negative)
+        "reask",  # same/similar question re-asked (implicit negative)
+        "copy",  # copy-to-clipboard (implicit positive)
+        "thumbs_up",
+        "thumbs_down",
+    }
+)
+
+
+def rsi_feedback_enabled() -> bool:
+    """Whether RSI feedback collection is turned on (default off)."""
+    return os.getenv("ENABLE_RSI_FEEDBACK", "false").lower() == "true"
+
+
+def log_qa_feedback(
+    *,
+    chat_id: int,
+    question: str,
+    answer: str,
+    feedback_signal: str,
+    message_id: int | None = None,
+    retrieved_chunks: Sequence[Any] | None = None,
+    session_id: str | None = None,
+    source: str = "implicit",
+) -> bool:
+    """Persist one feedback row. Returns True if written, False otherwise.
+
+    No-op (returns False) when ``ENABLE_RSI_FEEDBACK`` is off or the signal is
+    unknown. Never raises — a feedback-logging failure must not break the chat.
+    """
+    if not rsi_feedback_enabled():
+        return False
+    if feedback_signal not in VALID_SIGNALS:
+        return False
+
+    chunks_json = json.dumps(list(retrieved_chunks)) if retrieved_chunks else None
+    conn = None
+    try:
+        conn, cursor = get_db_connection()
+        cursor.execute(
+            """
+            INSERT INTO qa_feedback
+                (chat_id, message_id, question, retrieved_chunks, answer,
+                 feedback_signal, session_id, source)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            [
+                chat_id,
+                message_id,
+                question,
+                chunks_json,
+                answer,
+                feedback_signal,
+                session_id,
+                source,
+            ],
+        )
+        conn.commit()
+        return True
+    except Exception as exc:  # never break a chat on feedback logging
+        print(f"[rsi] log_qa_feedback failed: {exc}")
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -5,6 +5,7 @@ DROP TABLE IF EXISTS prompt_answers;
 DROP TABLE IF EXISTS prompts;
 DROP TABLE IF EXISTS chunks;
 DROP TABLE IF EXISTS documents;
+DROP TABLE IF EXISTS qa_feedback;
 DROP TABLE IF EXISTS messages;
 DROP TABLE IF EXISTS chat_share_chunks;
 DROP TABLE IF EXISTS chat_share_documents;
@@ -135,6 +136,23 @@ CREATE TABLE messages (
     FOREIGN KEY (chat_id) REFERENCES chats(id)
 );
 
+-- RSI feedback signals on Q&A answers (issue #220): training signal for the
+-- retrieval re-ranker / answer self-consistency loop. Written only when
+-- ENABLE_RSI_FEEDBACK is set; see database/qa_feedback.py.
+CREATE TABLE qa_feedback (
+    id INTEGER PRIMARY KEY AUTO_INCREMENT,
+    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    chat_id INTEGER NOT NULL,
+    message_id INTEGER DEFAULT(NULL),
+    question TEXT NOT NULL,
+    retrieved_chunks TEXT,
+    answer TEXT NOT NULL,
+    feedback_signal VARCHAR(32) NOT NULL,
+    session_id VARCHAR(255) DEFAULT(NULL),
+    source VARCHAR(16) NOT NULL DEFAULT 'implicit',
+    FOREIGN KEY (chat_id) REFERENCES chats(id)
+);
+
 -- Stores media files attached to user messages (images, audio clips, video clips)
 CREATE TABLE message_attachments (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
@@ -244,3 +262,4 @@ CREATE UNIQUE INDEX idx_user_chatbot_unique ON user_company_chatbots(user_id, pa
 CREATE INDEX idx_api_usage_user_id  ON api_usage(user_id);
 CREATE INDEX idx_api_usage_key_id   ON api_usage(api_key_id);
 CREATE INDEX idx_api_usage_created  ON api_usage(created);
+CREATE INDEX idx_qa_feedback_chat_id ON qa_feedback(chat_id);

--- a/backend/tests/test_qa_feedback.py
+++ b/backend/tests/test_qa_feedback.py
@@ -1,0 +1,92 @@
+"""Tests for database/qa_feedback.py — RSI feedback logging (issue #220, slice 1).
+
+No real DB: get_db_connection is monkeypatched with a fake connection, so these
+run offline under the conftest mysql stub.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from database import qa_feedback
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.cursor_obj = _FakeCursor()
+        self.committed = False
+        self.closed = False
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _install_fake(monkeypatch: Any) -> _FakeConn:
+    conn = _FakeConn()
+    monkeypatch.setattr(qa_feedback, "get_db_connection", lambda: (conn, conn.cursor_obj))
+    return conn
+
+
+def test_disabled_is_noop(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "false")
+    conn = _install_fake(monkeypatch)
+    assert qa_feedback.log_qa_feedback(
+        chat_id=1, question="q", answer="a", feedback_signal="copy"
+    ) is False
+    assert conn.cursor_obj.executed == []  # no DB write when the flag is off
+
+
+def test_enabled_writes_row(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+    conn = _install_fake(monkeypatch)
+    ok = qa_feedback.log_qa_feedback(
+        chat_id=7,
+        question="what is EBITDA",
+        answer="earnings before...",
+        feedback_signal="thumbs_up",
+        message_id=42,
+        retrieved_chunks=["c1", "c2"],
+        session_id="s1",
+        source="explicit",
+    )
+    assert ok is True
+    assert conn.committed is True and conn.closed is True
+    assert len(conn.cursor_obj.executed) == 1
+    sql, params = conn.cursor_obj.executed[0]
+    assert "INSERT INTO qa_feedback" in sql
+    assert params[0] == 7
+    assert params[5] == "thumbs_up"
+    assert params[3] == '["c1", "c2"]'  # retrieved_chunks serialized to JSON
+
+
+def test_invalid_signal_rejected(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+    conn = _install_fake(monkeypatch)
+    assert qa_feedback.log_qa_feedback(
+        chat_id=1, question="q", answer="a", feedback_signal="bogus"
+    ) is False
+    assert conn.cursor_obj.executed == []
+
+
+def test_db_failure_is_swallowed(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+
+    def _boom() -> Any:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(qa_feedback, "get_db_connection", _boom)
+    # Must not raise — feedback logging can never break a chat response.
+    assert qa_feedback.log_qa_feedback(
+        chat_id=1, question="q", answer="a", feedback_signal="copy"
+    ) is False


### PR DESCRIPTION
## What this is
**Slice 1 of #220** (RSI for document Q&A) — the foundation: a place to persist feedback signals, with a safe, opt-in logging path. **No behavior change yet** — nothing is wired into the live chat flow (that's slice 2).

## Changes
- **`alembic/versions/0002_qa_feedback.py`** — new `qa_feedback` table (chat_id, message_id, question, retrieved_chunks, answer, feedback_signal, session_id, source). Revision chain verified: `0001 → 0002 (head)`.
- **`database/qa_feedback.py`** — `log_qa_feedback(...)`: **opt-in** (no-op unless `ENABLE_RSI_FEEDBACK` is set) and **best-effort** (never raises — a feedback-logging failure must not break a chat response; mirrors `db_auth.touch_api_key_last_used`).
- **`database/schema.sql`** — qa_feedback table + index kept in sync with the migration.
- **`tests/test_qa_feedback.py`** — 4 tests: disabled→no-op, enabled→writes row (+JSON-serialized chunks), invalid signal rejected, DB failure swallowed.

## Why it's safe
- **Default OFF** → production behavior unchanged until enabled.
- Adding the table is inert; nothing writes unless the flag is on.
- No change to the chat/answer path in this slice.

## Testing
- `pytest tests/test_qa_feedback.py` → **4 passed** (offline, fake connection — no DB needed).
- ruff + mypy clean; `alembic history` shows `0001 → 0002`.

## Roadmap (#220)
- **Slice 1 (this PR)**: table + logging foundation.
- Slice 2: derive implicit signals (follow-up timing, re-ask, copy-to-clipboard) from the chat flow and call the logger.
- Slice 3: train a cross-encoder re-ranker on positive/negative pairs.
- Slice 4: answer self-consistency check.
