### PR TITLE
feat(rsi): implicit follow-up signal detection (#220, slice 2)

### DIFF
--- a/backend/database/feedback_signals.py
+++ b/backend/database/feedback_signals.py
@@ -1,0 +1,109 @@
+"""Implicit RSI feedback-signal detection for document Q&A — issue #220 (slice 2).
+
+Slice 1 (`database/qa_feedback.py`) added the `qa_feedback` table and the
+`log_qa_feedback()` writer. This slice derives an **implicit** signal from chat
+history with no UI change: a *rapid follow-up*. If the user asks again within a
+short window of the previous answer, that answer was probably incomplete — a
+soft-negative training signal for the RSI loop.
+
+Same constraints as slice 1: opt-in (`ENABLE_RSI_FEEDBACK`) and best-effort
+(detection/logging must never break a chat).
+
+Wiring (slice 2 integration, intentionally NOT done here): call
+`record_followup_if_any(user_email, chat_id, chat_type)` at the start of handling
+a new user turn, before the new message is persisted. Kept out of the live
+multi-agent path in this PR so the detection logic can land tested and reviewed
+first; the call site is a one-liner (see PR description).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from database.qa_feedback import log_qa_feedback, rsi_feedback_enabled
+
+# A follow-up within this many seconds of the previous answer is treated as an
+# implicit "that answer didn't fully land" signal.
+FOLLOWUP_WINDOW_SECS = 30.0
+
+# `retrieve_messages` is bound lazily from `database.db` on first use. This keeps
+# the module importable (and `detect_followup_signal` unit-testable) without
+# pulling the heavy DB module, and gives tests a clean seam to patch.
+_retrieve_messages: Any = None
+
+
+def _is_user(message: dict[str, Any]) -> bool:
+    return bool(message.get("sent_from_user"))
+
+
+def _age_seconds(created: Any, now: datetime) -> float | None:
+    """Seconds between ``created`` and ``now``; None if ``created`` isn't a datetime."""
+    if isinstance(created, datetime):
+        return (now - created).total_seconds()
+    return None  # unknown timestamp type → skip (best-effort)
+
+
+def detect_followup_signal(
+    messages: list[dict[str, Any]],
+    now: datetime,
+    window_secs: float = FOLLOWUP_WINDOW_SECS,
+) -> dict[str, Any] | None:
+    """Return a qa_feedback record for the most recent answer if the user is
+    following up within ``window_secs`` of it, else ``None``.
+
+    ``messages`` is chronological (oldest → newest), as returned by
+    ``database.db.retrieve_messages`` (dicts with ``created``, ``id``,
+    ``message_text``, ``sent_from_user``, ``relevant_chunks``).
+    """
+    if not messages:
+        return None
+    last = messages[-1]
+    if _is_user(last):
+        return None  # last turn is the user's; no answer to score yet
+    age = _age_seconds(last.get("created"), now)
+    if age is None or age < 0 or age > window_secs:
+        return None
+
+    question = ""
+    for prev in reversed(messages[:-1]):
+        if _is_user(prev):
+            question = str(prev.get("message_text", ""))
+            break
+
+    return {
+        "message_id": last.get("id"),
+        "question": question,
+        "answer": str(last.get("message_text", "")),
+        "retrieved_chunks": last.get("relevant_chunks"),
+        "feedback_signal": "followup",
+        "source": "implicit",
+    }
+
+
+def record_followup_if_any(
+    user_email: str,
+    chat_id: int,
+    chat_type: int,
+    now: datetime | None = None,
+) -> bool:
+    """Best-effort: detect a rapid follow-up against this chat's history and log it.
+
+    No-op (returns False) when RSI feedback is disabled. Never raises — a feedback
+    side-channel must not break the chat response.
+    """
+    global _retrieve_messages
+    if not rsi_feedback_enabled():
+        return False
+    try:
+        if _retrieve_messages is None:
+            from database.db import retrieve_messages
+
+            _retrieve_messages = retrieve_messages
+        messages = _retrieve_messages(user_email, chat_id, chat_type) or []
+        record = detect_followup_signal(messages, now or datetime.now())
+        if record is None:
+            return False
+        return log_qa_feedback(chat_id=chat_id, **record)
+    except Exception as exc:  # detection must never break a chat
+        print(f"[rsi] record_followup_if_any failed: {exc}")
+        return False

--- a/backend/database/qa_feedback.py
+++ b/backend/database/qa_feedback.py
@@ -46,7 +46,7 @@ def log_qa_feedback(
     answer: str,
     feedback_signal: str,
     message_id: int | None = None,
-    retrieved_chunks: Sequence[Any] | None = None,
+    retrieved_chunks: str | Sequence[Any] | None = None,
     session_id: str | None = None,
     source: str = "implicit",
 ) -> bool:
@@ -60,7 +60,14 @@ def log_qa_feedback(
     if feedback_signal not in VALID_SIGNALS:
         return False
 
-    chunks_json = json.dumps(list(retrieved_chunks)) if retrieved_chunks else None
+    # retrieved_chunks may be a pre-serialized string (e.g. messages.relevant_chunks
+    # from the DB) or a fresh sequence of chunks — handle both.
+    if retrieved_chunks is None:
+        chunks_json = None
+    elif isinstance(retrieved_chunks, str):
+        chunks_json = retrieved_chunks
+    else:
+        chunks_json = json.dumps(list(retrieved_chunks))
     conn = None
     try:
         conn, cursor = get_db_connection()

--- a/backend/tests/test_feedback_signals.py
+++ b/backend/tests/test_feedback_signals.py
@@ -1,0 +1,122 @@
+"""Tests for database/feedback_signals.py — implicit RSI signals (issue #220, slice 2).
+
+Pure logic + best-effort orchestration; deps (retrieve_messages, log_qa_feedback)
+are monkeypatched, so these run offline under the conftest mysql stub.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from database import feedback_signals as fs
+
+NOW = datetime(2026, 6, 14, 12, 0, 0)
+
+
+def _msg(
+    text: str,
+    is_user: bool,
+    created: Any,
+    mid: int | None = None,
+    chunks: Any = None,
+) -> dict[str, Any]:
+    return {
+        "message_text": text,
+        "sent_from_user": 1 if is_user else 0,
+        "created": created,
+        "id": mid,
+        "relevant_chunks": chunks,
+    }
+
+
+# --- detect_followup_signal ------------------------------------------------ #
+
+def test_detect_followup_within_window() -> None:
+    msgs = [
+        _msg("what is EBITDA?", True, NOW - timedelta(seconds=40)),
+        _msg("EBITDA is ...", False, NOW - timedelta(seconds=5), mid=99, chunks="c1|c2"),
+    ]
+    rec = fs.detect_followup_signal(msgs, NOW)
+    assert rec is not None
+    assert rec["feedback_signal"] == "followup"
+    assert rec["message_id"] == 99
+    assert rec["question"] == "what is EBITDA?"
+    assert rec["answer"] == "EBITDA is ..."
+    assert rec["retrieved_chunks"] == "c1|c2"
+
+
+def test_detect_none_when_answer_too_old() -> None:
+    msgs = [
+        _msg("q", True, NOW - timedelta(seconds=120)),
+        _msg("a", False, NOW - timedelta(seconds=60), mid=1),  # 60s > 30s window
+    ]
+    assert fs.detect_followup_signal(msgs, NOW) is None
+
+
+def test_detect_none_when_last_is_user() -> None:
+    msgs = [
+        _msg("a", False, NOW - timedelta(seconds=5), mid=1),
+        _msg("q2", True, NOW),
+    ]
+    assert fs.detect_followup_signal(msgs, NOW) is None
+
+
+def test_detect_none_empty() -> None:
+    assert fs.detect_followup_signal([], NOW) is None
+
+
+def test_detect_none_non_datetime_created() -> None:
+    msgs = [_msg("q", True, "2026-06-14"), _msg("a", False, "2026-06-14", mid=1)]
+    assert fs.detect_followup_signal(msgs, NOW) is None
+
+
+# --- record_followup_if_any ------------------------------------------------ #
+
+def test_record_disabled_is_noop(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "false")
+
+    def _fail(*a: Any, **k: Any) -> Any:
+        raise AssertionError("must not be called when disabled")
+
+    monkeypatch.setattr(fs, "_retrieve_messages", _fail)
+    monkeypatch.setattr(fs, "log_qa_feedback", _fail)
+    assert fs.record_followup_if_any("u@x", 1, 0) is False
+
+
+def test_record_enabled_logs_followup(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+    msgs = [
+        _msg("q", True, NOW - timedelta(seconds=40)),
+        _msg("a", False, NOW - timedelta(seconds=3), mid=7, chunks="c"),
+    ]
+    monkeypatch.setattr(fs, "_retrieve_messages", lambda *a, **k: msgs)
+    logged: dict[str, Any] = {}
+
+    def _fake_log(**kw: Any) -> bool:
+        logged.update(kw)
+        return True
+
+    monkeypatch.setattr(fs, "log_qa_feedback", _fake_log)
+    assert fs.record_followup_if_any("u@x", 5, 0, now=NOW) is True
+    assert logged["chat_id"] == 5
+    assert logged["feedback_signal"] == "followup"
+    assert logged["message_id"] == 7
+
+
+def test_record_no_followup_returns_false(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+    msgs = [_msg("a", False, NOW - timedelta(seconds=300), mid=1)]  # too old
+    monkeypatch.setattr(fs, "_retrieve_messages", lambda *a, **k: msgs)
+    monkeypatch.setattr(fs, "log_qa_feedback", lambda **k: True)
+    assert fs.record_followup_if_any("u@x", 5, 0, now=NOW) is False
+
+
+def test_record_swallows_exception(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+
+    def _boom(*a: Any, **k: Any) -> Any:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(fs, "_retrieve_messages", _boom)
+    assert fs.record_followup_if_any("u@x", 5, 0) is False

--- a/backend/tests/test_qa_feedback.py
+++ b/backend/tests/test_qa_feedback.py
@@ -70,6 +70,19 @@ def test_enabled_writes_row(monkeypatch: Any) -> None:
     assert params[3] == '["c1", "c2"]'  # retrieved_chunks serialized to JSON
 
 
+def test_pre_serialized_string_chunks_stored_as_is(monkeypatch: Any) -> None:
+    # messages.relevant_chunks comes from the DB as an already-serialized string;
+    # it must be stored verbatim, not split into characters by list().
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+    conn = _install_fake(monkeypatch)
+    assert qa_feedback.log_qa_feedback(
+        chat_id=1, question="q", answer="a", feedback_signal="followup",
+        retrieved_chunks="chunk-a|chunk-b",
+    ) is True
+    _sql, params = conn.cursor_obj.executed[0]
+    assert params[3] == "chunk-a|chunk-b"
+
+
 def test_invalid_signal_rejected(monkeypatch: Any) -> None:
     monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
     conn = _install_fake(monkeypatch)


### PR DESCRIPTION
## What this is
**Slice 2 of #220** (RSI for document Q&A). Slice 1 (#223) added the `qa_feedback` table + `log_qa_feedback()` writer; this slice adds the first **implicit** signal — a *rapid follow-up* — derived from chat history with **no UI change**.

## Changes
- **`database/feedback_signals.py`** (new):
  - `detect_followup_signal(messages, now)` — pure: if the most recent answer is younger than 30s (the user is following up almost immediately), returns a `qa_feedback` record flagging that answer as a soft-negative training signal.
  - `record_followup_if_any(user_email, chat_id, chat_type)` — opt-in (`ENABLE_RSI_FEEDBACK`), best-effort orchestration: reads history → detects → logs. Never raises.
- **`database/qa_feedback.py`** — `log_qa_feedback` now accepts a pre-serialized chunks **string** (e.g. `messages.relevant_chunks` from the DB) in addition to a fresh sequence, so slice-2 records store chunks correctly instead of splitting the string.

## Not wired into the live chat path (by design)
The detection logic lands tested first; the integration is a **one-liner** at the start of handling a new user turn:
```python
from database.feedback_signals import record_followup_if_any
record_followup_if_any(user_email, chat_id, chat_type)  # best-effort; no-op unless ENABLE_RSI_FEEDBACK
```
Kept separate so the logic is reviewed before touching the hot multi-agent streaming path. Happy to add the call wherever preferred (likely the chat entry, before the new message is persisted).

## Safety
- **Opt-in (default OFF)** + **best-effort (never raises)** → zero behavior change until enabled.
- `detect_followup_signal` is pure; `record_followup_if_any` swallows all errors.

## Testing
- `pytest tests/test_feedback_signals.py tests/test_qa_feedback.py` → **14 passed** (offline, mocked deps — no DB/network).
- ruff + mypy clean.

Builds on #223. Roadmap: slice 3 = cross-encoder re-ranker trained on the collected pairs; slice 4 = answer self-consistency check.
