### PR TITLE
fix(auth): read token from res.data.token (web + desktop + mobile)

### DIFF
--- a/packages/desktop/frontend/src/api.ts
+++ b/packages/desktop/frontend/src/api.ts
@@ -23,13 +23,13 @@ async function client() {
 export async function login(email: string, password: string) {
   const c = await client();
   const res = await c.post("/auth/login", { email, password });
-  return res.data.access_token as string;
+  return res.data.token as string;
 }
 
 export async function register(email: string, password: string, name: string) {
   const c = await client();
   const res = await c.post("/auth/register", { email, password, name });
-  return res.data.access_token as string;
+  return res.data.token as string;
 }
 
 export async function getSessions() {

--- a/packages/mobile/src/api.ts
+++ b/packages/mobile/src/api.ts
@@ -21,12 +21,12 @@ export interface Message {
 
 export async function login(email: string, password: string) {
   const res = await api.post("/auth/login", { email, password });
-  return res.data.access_token as string;
+  return res.data.token as string;
 }
 
 export async function register(email: string, password: string, name: string) {
   const res = await api.post("/auth/register", { email, password, name });
-  return res.data.access_token as string;
+  return res.data.token as string;
 }
 
 export async function getSessions(): Promise<Session[]> {

--- a/packages/web/src/pages/LoginPage.tsx
+++ b/packages/web/src/pages/LoginPage.tsx
@@ -19,7 +19,7 @@ export default function LoginPage() {
     setError("");
     try {
       const res = await axios.post("/auth/login", { email, password });
-      setToken(res.data.access_token);
+      setToken(res.data.token);
       nav("/");
     } catch (err: any) {
       setError(err.response?.data?.error || "Login failed");

--- a/packages/web/src/pages/RegisterPage.tsx
+++ b/packages/web/src/pages/RegisterPage.tsx
@@ -20,7 +20,7 @@ export default function RegisterPage() {
     setError("");
     try {
       const res = await axios.post("/auth/register", { email, password, name });
-      setToken(res.data.access_token);
+      setToken(res.data.token);
       nav("/");
     } catch (err: any) {
       setError(err.response?.data?.error || "Registration failed");


### PR DESCRIPTION
Backend auth handler returns { token } for register/login/refresh (confirmed; there's a test asserting token), but every frontend auth client read res.data.access_token -> undefined -> user blocked right after sign-in. Susana hit this locally and confirmed switching to token fixes it.

Aligns all three packages to res.data.token (6 sites / 4 files):
- web: RegisterPage.tsx, LoginPage.tsx
- desktop: frontend/src/api.ts (login + register)
- mobile: src/api.ts (login + register)

Verification: backend contract confirmed (api_endpoints/auth/handler.py returns { token }, test asserts it); Susana already verified the web fix unblocks login locally. Browser-preview check needs full stack + real auth, hence contract-level verification.