### PR TITLE
Add browser action safety policy and execution trace recording

### DIFF
--- a/backend/agents/browser_policy.py
+++ b/backend/agents/browser_policy.py
@@ -1,0 +1,327 @@
+"""Browser/computer-use action safety policy and execution trace recording.
+
+Part of issue #139 ("Add browser and computer-use execution for real-world
+web tasks"). This module implements the *policy gating* and *execution
+trace* pieces of that epic:
+
+- ``ActionSafetyLevel``: the four safety tiers called out in the issue
+  (read-only, form-fill, submit, destructive).
+- ``classify_action``: maps a browser action type (e.g. ``"click"``,
+  ``"submit_form"``, ``"delete_file"``) to its safety level.
+- ``BrowserActionPolicy``: gates submit/destructive actions behind an
+  explicit allow-list and/or an approval callback, and raises
+  ``PolicyViolation`` when a disallowed action is attempted. Every
+  decision (allowed or denied) is auditable via ``decisions``.
+- ``BrowserSessionTrace`` / ``BrowserStepTrace``: structured, replayable
+  step traces for a single browser session (run), isolated per
+  workspace/project, so failed steps can be inspected and replayed.
+
+This module intentionally has **no external dependencies** (stdlib only)
+so it can be unit tested without pulling in the heavy optional deps
+(langchain, anthropic, etc.) that the rest of ``agents/`` requires. Actual
+browser driving (Playwright/Selenium), credential injection, and artifact
+storage (screenshots to S3/disk) are out of scope for this module — see
+the PR description for what's deferred.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Optional
+
+
+class ActionSafetyLevel(str, Enum):
+    """Safety tiers for browser/computer-use actions, per issue #139.
+
+    Ordered from least to most dangerous; comparisons use this ordering.
+    """
+
+    READ_ONLY = "read_only"
+    FORM_FILL = "form_fill"
+    SUBMIT = "submit"
+    DESTRUCTIVE = "destructive"
+
+    @property
+    def rank(self) -> int:
+        return _LEVEL_RANK[self]
+
+
+_LEVEL_RANK = {
+    ActionSafetyLevel.READ_ONLY: 0,
+    ActionSafetyLevel.FORM_FILL: 1,
+    ActionSafetyLevel.SUBMIT: 2,
+    ActionSafetyLevel.DESTRUCTIVE: 3,
+}
+
+# Canonical mapping of action types to safety levels. Unknown action types
+# default to DESTRUCTIVE (fail closed) via classify_action's fallback.
+_ACTION_SAFETY_MAP: dict[str, ActionSafetyLevel] = {
+    # Read-only: navigation, observation, extraction
+    "navigate": ActionSafetyLevel.READ_ONLY,
+    "screenshot": ActionSafetyLevel.READ_ONLY,
+    "extract_dom": ActionSafetyLevel.READ_ONLY,
+    "extract_text": ActionSafetyLevel.READ_ONLY,
+    "scroll": ActionSafetyLevel.READ_ONLY,
+    "wait_for_selector": ActionSafetyLevel.READ_ONLY,
+    "read_cookies": ActionSafetyLevel.READ_ONLY,
+    "hover": ActionSafetyLevel.READ_ONLY,
+    # Form-fill: populating inputs, uploading files, non-committing clicks
+    "fill_field": ActionSafetyLevel.FORM_FILL,
+    "select_option": ActionSafetyLevel.FORM_FILL,
+    "upload_file": ActionSafetyLevel.FORM_FILL,
+    "click": ActionSafetyLevel.FORM_FILL,
+    "check_checkbox": ActionSafetyLevel.FORM_FILL,
+    "type_text": ActionSafetyLevel.FORM_FILL,
+    # Submit: actions that send data externally / commit state
+    "submit_form": ActionSafetyLevel.SUBMIT,
+    "click_submit_button": ActionSafetyLevel.SUBMIT,
+    "send_application": ActionSafetyLevel.SUBMIT,
+    "post_message": ActionSafetyLevel.SUBMIT,
+    "publish": ActionSafetyLevel.SUBMIT,
+    # Destructive: irreversible or account-altering actions
+    "delete_file": ActionSafetyLevel.DESTRUCTIVE,
+    "delete_account": ActionSafetyLevel.DESTRUCTIVE,
+    "cancel_subscription": ActionSafetyLevel.DESTRUCTIVE,
+    "make_payment": ActionSafetyLevel.DESTRUCTIVE,
+    "change_password": ActionSafetyLevel.DESTRUCTIVE,
+    "delete_post": ActionSafetyLevel.DESTRUCTIVE,
+}
+
+
+def classify_action(action_type: str) -> ActionSafetyLevel:
+    """Classify a browser action type into a safety level.
+
+    Unknown action types are treated as DESTRUCTIVE (fail closed) so new,
+    unrecognized capabilities are gated by default rather than silently
+    allowed.
+    """
+    return _ACTION_SAFETY_MAP.get(action_type, ActionSafetyLevel.DESTRUCTIVE)
+
+
+def register_action_type(action_type: str, level: ActionSafetyLevel) -> None:
+    """Register (or override) the safety level for an action type.
+
+    Allows callers (e.g. a future Playwright tool layer) to extend the
+    known action vocabulary without modifying this module.
+    """
+    _ACTION_SAFETY_MAP[action_type] = level
+
+
+class PolicyViolation(Exception):
+    """Raised when an action is attempted that the active policy denies."""
+
+    def __init__(self, action_type: str, level: ActionSafetyLevel, reason: str):
+        self.action_type = action_type
+        self.level = level
+        self.reason = reason
+        super().__init__(
+            f"Action '{action_type}' (level={level.value}) denied: {reason}"
+        )
+
+
+@dataclass
+class PolicyDecision:
+    """An auditable record of a single policy check."""
+
+    action_type: str
+    level: ActionSafetyLevel
+    allowed: bool
+    reason: str
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action_type": self.action_type,
+            "level": self.level.value,
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "timestamp": self.timestamp,
+        }
+
+
+ApprovalCallback = Callable[[str, ActionSafetyLevel, dict[str, Any]], bool]
+
+
+class BrowserActionPolicy:
+    """Gates browser actions by safety level.
+
+    - READ_ONLY and FORM_FILL actions are always allowed.
+    - SUBMIT actions are allowed only if ``allow_submit`` is True (or an
+      ``approval_callback`` explicitly approves the specific call).
+    - DESTRUCTIVE actions are allowed only if ``allow_destructive`` is True
+      AND (no approval callback is set, or the callback approves).
+
+    Every check — allowed or denied — is appended to ``self.decisions`` for
+    later audit, satisfying the "auditable after the run" acceptance
+    criterion.
+    """
+
+    def __init__(
+        self,
+        allow_submit: bool = False,
+        allow_destructive: bool = False,
+        approval_callback: Optional[ApprovalCallback] = None,
+    ) -> None:
+        self.allow_submit = allow_submit
+        self.allow_destructive = allow_destructive
+        self.approval_callback = approval_callback
+        self.decisions: list[PolicyDecision] = []
+
+    def check(self, action_type: str, params: Optional[dict[str, Any]] = None) -> PolicyDecision:
+        """Evaluate whether ``action_type`` is permitted. Does not raise."""
+        params = params or {}
+        level = classify_action(action_type)
+
+        if level in (ActionSafetyLevel.READ_ONLY, ActionSafetyLevel.FORM_FILL):
+            decision = PolicyDecision(action_type, level, True, "auto-allowed (non-gated level)")
+        elif level is ActionSafetyLevel.SUBMIT:
+            if not self.allow_submit:
+                decision = PolicyDecision(action_type, level, False, "submit actions disabled for this run")
+            elif self.approval_callback is not None and not self.approval_callback(action_type, level, params):
+                decision = PolicyDecision(action_type, level, False, "rejected by approval callback")
+            else:
+                decision = PolicyDecision(action_type, level, True, "submit allowed")
+        else:  # DESTRUCTIVE
+            if not self.allow_destructive:
+                decision = PolicyDecision(action_type, level, False, "destructive actions disabled for this run")
+            elif self.approval_callback is not None and not self.approval_callback(action_type, level, params):
+                decision = PolicyDecision(action_type, level, False, "rejected by approval callback")
+            else:
+                decision = PolicyDecision(action_type, level, True, "destructive action explicitly approved")
+
+        self.decisions.append(decision)
+        return decision
+
+    def enforce(self, action_type: str, params: Optional[dict[str, Any]] = None) -> PolicyDecision:
+        """Like ``check``, but raises ``PolicyViolation`` if denied."""
+        decision = self.check(action_type, params)
+        if not decision.allowed:
+            raise PolicyViolation(action_type, decision.level, decision.reason)
+        return decision
+
+    def audit_log(self) -> list[dict[str, Any]]:
+        return [d.to_dict() for d in self.decisions]
+
+
+@dataclass
+class BrowserStepTrace:
+    """A single recorded step within a browser session run."""
+
+    step_id: str
+    action_type: str
+    level: ActionSafetyLevel
+    status: str  # "pending" | "success" | "failure" | "denied"
+    params: dict[str, Any] = field(default_factory=dict)
+    result: Optional[dict[str, Any]] = None
+    error: Optional[str] = None
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
+    started_at: float = field(default_factory=time.time)
+    ended_at: Optional[float] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_id": self.step_id,
+            "action_type": self.action_type,
+            "level": self.level.value,
+            "status": self.status,
+            "params": self.params,
+            "result": self.result,
+            "error": self.error,
+            "artifacts": self.artifacts,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+        }
+
+
+class BrowserSessionTrace:
+    """Records the structured step trace for one isolated browser session.
+
+    A session is scoped to a single (workspace_id, project_id, run_id)
+    tuple so traces never leak across tenants/runs, addressing the
+    "isolated per run and linked to the owning workspace/project"
+    acceptance criterion. Real artifact storage (screenshots/logs to
+    blob storage) is out of scope here; ``add_artifact`` only records
+    structured references (e.g. a path or URI) into the trace.
+    """
+
+    def __init__(
+        self,
+        workspace_id: str,
+        project_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        policy: Optional[BrowserActionPolicy] = None,
+    ) -> None:
+        self.session_id = str(uuid.uuid4())
+        self.workspace_id = workspace_id
+        self.project_id = project_id
+        self.run_id = run_id or str(uuid.uuid4())
+        self.policy = policy or BrowserActionPolicy()
+        self.steps: list[BrowserStepTrace] = []
+        self.created_at = time.time()
+
+    def start_step(self, action_type: str, params: Optional[dict[str, Any]] = None) -> BrowserStepTrace:
+        """Run the policy check for ``action_type`` and open a new step.
+
+        If the policy denies the action, the step is recorded with
+        status "denied" and ``PolicyViolation`` is re-raised so callers
+        cannot silently proceed with a gated action.
+        """
+        params = params or {}
+        level = classify_action(action_type)
+        decision = self.policy.check(action_type, params)
+        step = BrowserStepTrace(
+            step_id=str(uuid.uuid4()),
+            action_type=action_type,
+            level=level,
+            status="pending" if decision.allowed else "denied",
+            params=params,
+        )
+        self.steps.append(step)
+        if not decision.allowed:
+            step.ended_at = time.time()
+            step.error = decision.reason
+            raise PolicyViolation(action_type, level, decision.reason)
+        return step
+
+    @staticmethod
+    def complete_step(step: BrowserStepTrace, result: Optional[dict[str, Any]] = None) -> None:
+        step.status = "success"
+        step.result = result
+        step.ended_at = time.time()
+
+    @staticmethod
+    def fail_step(step: BrowserStepTrace, error: str) -> None:
+        step.status = "failure"
+        step.error = error
+        step.ended_at = time.time()
+
+    @staticmethod
+    def add_artifact(step: BrowserStepTrace, artifact_type: str, uri: str, **meta: Any) -> None:
+        step.artifacts.append({"type": artifact_type, "uri": uri, **meta})
+
+    def failed_steps(self) -> list[BrowserStepTrace]:
+        return [s for s in self.steps if s.status in ("failure", "denied")]
+
+    def replay_plan(self) -> list[dict[str, Any]]:
+        """Return the ordered list of failed/denied steps with enough
+        context (action_type + params) to retry them, satisfying the
+        "failed steps can be replayed and debugged" acceptance criterion.
+        """
+        return [
+            {"step_id": s.step_id, "action_type": s.action_type, "params": s.params, "status": s.status, "error": s.error}
+            for s in self.failed_steps()
+        ]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "workspace_id": self.workspace_id,
+            "project_id": self.project_id,
+            "run_id": self.run_id,
+            "created_at": self.created_at,
+            "steps": [s.to_dict() for s in self.steps],
+            "audit_log": self.policy.audit_log(),
+        }

--- a/backend/tests/test_browser_policy.py
+++ b/backend/tests/test_browser_policy.py
@@ -1,0 +1,225 @@
+"""Tests for the browser/computer-use action safety policy (issue #139).
+
+Loaded by file path the same way ``test_config.py`` loads
+``agents/config.py`` — ``agents/browser_policy.py`` only imports the
+standard library, so it can be unit tested without pulling in the heavy
+optional deps (langchain, anthropic, etc.) required by ``agents/__init__``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_browser_policy() -> Any:
+    path = Path(__file__).resolve().parents[1] / "agents" / "browser_policy.py"
+    spec = importlib.util.spec_from_file_location("_real_browser_policy", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # dataclass() needs the module registered in sys.modules to resolve
+    # forward-referenced type annotations.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bp = _load_browser_policy()
+
+
+# ---------------------------------------------------------------------------
+# classify_action
+# ---------------------------------------------------------------------------
+
+
+def test_classify_known_actions() -> None:
+    assert bp.classify_action("navigate") == bp.ActionSafetyLevel.READ_ONLY
+    assert bp.classify_action("screenshot") == bp.ActionSafetyLevel.READ_ONLY
+    assert bp.classify_action("fill_field") == bp.ActionSafetyLevel.FORM_FILL
+    assert bp.classify_action("click") == bp.ActionSafetyLevel.FORM_FILL
+    assert bp.classify_action("submit_form") == bp.ActionSafetyLevel.SUBMIT
+    assert bp.classify_action("send_application") == bp.ActionSafetyLevel.SUBMIT
+    assert bp.classify_action("delete_account") == bp.ActionSafetyLevel.DESTRUCTIVE
+    assert bp.classify_action("make_payment") == bp.ActionSafetyLevel.DESTRUCTIVE
+
+
+def test_classify_unknown_action_fails_closed() -> None:
+    assert bp.classify_action("totally_unknown_action") == bp.ActionSafetyLevel.DESTRUCTIVE
+
+
+def test_register_action_type_overrides_mapping() -> None:
+    bp.register_action_type("custom_read_action", bp.ActionSafetyLevel.READ_ONLY)
+    assert bp.classify_action("custom_read_action") == bp.ActionSafetyLevel.READ_ONLY
+
+
+def test_safety_level_rank_ordering() -> None:
+    assert bp.ActionSafetyLevel.READ_ONLY.rank < bp.ActionSafetyLevel.FORM_FILL.rank
+    assert bp.ActionSafetyLevel.FORM_FILL.rank < bp.ActionSafetyLevel.SUBMIT.rank
+    assert bp.ActionSafetyLevel.SUBMIT.rank < bp.ActionSafetyLevel.DESTRUCTIVE.rank
+
+
+# ---------------------------------------------------------------------------
+# BrowserActionPolicy
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_and_form_fill_always_allowed() -> None:
+    policy = bp.BrowserActionPolicy()  # no submit/destructive allowed
+    assert policy.check("navigate").allowed is True
+    assert policy.check("fill_field").allowed is True
+
+
+def test_submit_denied_by_default() -> None:
+    policy = bp.BrowserActionPolicy()
+    decision = policy.check("submit_form")
+    assert decision.allowed is False
+    assert "disabled" in decision.reason
+
+
+def test_submit_allowed_when_enabled() -> None:
+    policy = bp.BrowserActionPolicy(allow_submit=True)
+    decision = policy.check("submit_form")
+    assert decision.allowed is True
+
+
+def test_destructive_denied_by_default_even_if_submit_allowed() -> None:
+    policy = bp.BrowserActionPolicy(allow_submit=True)
+    decision = policy.check("delete_account")
+    assert decision.allowed is False
+
+
+def test_destructive_allowed_when_enabled() -> None:
+    policy = bp.BrowserActionPolicy(allow_destructive=True)
+    decision = policy.check("delete_account")
+    assert decision.allowed is True
+
+
+def test_approval_callback_can_reject_otherwise_allowed_action() -> None:
+    policy = bp.BrowserActionPolicy(allow_submit=True, approval_callback=lambda *_: False)
+    decision = policy.check("submit_form")
+    assert decision.allowed is False
+    assert "approval callback" in decision.reason
+
+
+def test_approval_callback_can_approve_destructive_action() -> None:
+    policy = bp.BrowserActionPolicy(allow_destructive=True, approval_callback=lambda *_: True)
+    decision = policy.check("delete_account")
+    assert decision.allowed is True
+
+
+def test_enforce_raises_policy_violation_when_denied() -> None:
+    policy = bp.BrowserActionPolicy()
+    with pytest.raises(bp.PolicyViolation):
+        policy.enforce("submit_form")
+
+
+def test_enforce_returns_decision_when_allowed() -> None:
+    policy = bp.BrowserActionPolicy()
+    decision = policy.enforce("navigate")
+    assert decision.allowed is True
+
+
+def test_audit_log_records_every_decision() -> None:
+    policy = bp.BrowserActionPolicy(allow_submit=True)
+    policy.check("navigate")
+    policy.check("submit_form")
+    policy.check("delete_account")
+    log = policy.audit_log()
+    assert len(log) == 3
+    assert [entry["allowed"] for entry in log] == [True, True, False]
+
+
+# ---------------------------------------------------------------------------
+# BrowserSessionTrace
+# ---------------------------------------------------------------------------
+
+
+def test_session_trace_is_scoped_to_workspace_and_run() -> None:
+    trace = bp.BrowserSessionTrace(workspace_id="ws-1", project_id="proj-9", run_id="run-42")
+    assert trace.workspace_id == "ws-1"
+    assert trace.project_id == "proj-9"
+    assert trace.run_id == "run-42"
+    assert trace.session_id  # auto-generated, unique per session
+
+
+def test_two_sessions_have_distinct_session_ids() -> None:
+    t1 = bp.BrowserSessionTrace(workspace_id="ws-1")
+    t2 = bp.BrowserSessionTrace(workspace_id="ws-1")
+    assert t1.session_id != t2.session_id
+
+
+def test_start_step_records_pending_step_on_allowed_action() -> None:
+    trace = bp.BrowserSessionTrace(workspace_id="ws-1")
+    step = trace.start_step("navigate", {"url": "https://example.com"})
+    assert step.status == "pending"
+    assert step.level == bp.ActionSafetyLevel.READ_ONLY
+    assert len(trace.steps) == 1
+
+
+def test_start_step_raises_and_records_denied_step_for_gated_action() -> None:
+    trace = bp.BrowserSessionTrace(workspace_id="ws-1")
+    with pytest.raises(bp.PolicyViolation):
+        trace.start_step("submit_form", {"form_id": "apply"})
+    assert len(trace.steps) == 1
+    assert trace.steps[0].status == "denied"
+
+
+def test_complete_step_and_fail_step() -> None:
+    trace = bp.BrowserSessionTrace(workspace_id="ws-1")
+    step = trace.start_step("navigate")
+    trace.complete_step(step, result={"title": "Example"})
+    assert step.status == "success"
+    assert step.result == {"title": "Example"}
+    assert step.ended_at is not None
+
+    step2 = trace.start_step("fill_field")
+    trace.fail_step(step2, error="selector not found")
+    assert step2.status == "failure"
+    assert step2.error == "selector not found"
+
+
+def test_add_artifact_attaches_to_step() -> None:
+    trace = bp.BrowserSessionTrace(workspace_id="ws-1")
+    step = trace.start_step("screenshot")
+    trace.add_artifact(step, "screenshot", "file:///tmp/shot.png", page="apply-form")
+    assert step.artifacts == [{"type": "screenshot", "uri": "file:///tmp/shot.png", "page": "apply-form"}]
+
+
+def test_failed_steps_and_replay_plan() -> None:
+    policy = bp.BrowserActionPolicy()  # submit disabled -> will be denied
+    trace = bp.BrowserSessionTrace(workspace_id="ws-1", policy=policy)
+
+    step1 = trace.start_step("navigate")
+    trace.complete_step(step1)
+
+    step2 = trace.start_step("fill_field", {"field": "email"})
+    trace.fail_step(step2, error="timeout")
+
+    with pytest.raises(bp.PolicyViolation):
+        trace.start_step("submit_form", {"form_id": "apply"})
+
+    failed = trace.failed_steps()
+    assert len(failed) == 2
+    assert {s.status for s in failed} == {"failure", "denied"}
+
+    plan = trace.replay_plan()
+    assert len(plan) == 2
+    assert plan[0]["action_type"] == "fill_field"
+    assert plan[1]["action_type"] == "submit_form"
+
+
+def test_to_dict_is_json_serializable_shape() -> None:
+    trace = bp.BrowserSessionTrace(workspace_id="ws-1", project_id="proj-1")
+    step = trace.start_step("navigate")
+    trace.complete_step(step, result={"ok": True})
+
+    data = trace.to_dict()
+    assert data["workspace_id"] == "ws-1"
+    assert data["project_id"] == "proj-1"
+    assert len(data["steps"]) == 1
+    assert data["steps"][0]["status"] == "success"
+    assert isinstance(data["audit_log"], list)


### PR DESCRIPTION
Addresses #139

## What this implements

Issue #139 is a large epic ("Add browser and computer-use execution for real-world web tasks") covering browser automation runtime, session isolation, credential injection, page interaction, screenshots/artifacts, action safety levels, and replayable execution traces. This PR implements a scoped, self-contained, fully-tested slice of that epic: **the action-safety policy and execution-trace data layer**, without the browser driver itself.

New module: `backend/agents/browser_policy.py` (stdlib-only, no external deps, consistent with how `agents/config.py` is kept dependency-free for fast unit testing):

- `ActionSafetyLevel` — the four tiers called out in the issue: `read_only`, `form_fill`, `submit`, `destructive`.
- `classify_action(action_type)` — maps action types (`navigate`, `click`, `submit_form`, `delete_account`, etc.) to a safety level. Unknown action types fail closed to `destructive`.
- `register_action_type(...)` — lets a future browser-driver layer extend the action vocabulary.
- `BrowserActionPolicy` — gates `submit` and `destructive` actions behind explicit opt-in flags (`allow_submit`, `allow_destructive`) and an optional `approval_callback`. `read_only`/`form_fill` actions are always allowed. Every decision (allowed or denied) is recorded in `policy.decisions` / `audit_log()` for post-run auditing. `enforce()` raises `PolicyViolation` on denial.
- `BrowserSessionTrace` / `BrowserStepTrace` — structured execution trace for one browser session, scoped to `(workspace_id, project_id, run_id)` so traces never leak across tenants/runs. Each step records its safety level, status (`pending`/`success`/`failure`/`denied`), params, result/error, and artifact references (e.g. screenshot URIs). `failed_steps()` / `replay_plan()` surface failed or policy-denied steps with enough context to retry them. `to_dict()` produces a JSON-serializable shape suitable for persistence.

Tests: `backend/tests/test_browser_policy.py` — 22 tests covering action classification (including the fail-closed default and overrides), all policy gating combinations (read-only/form-fill always allowed, submit/destructive denied by default and allowed when opted in, approval-callback override in both directions, `enforce` raising `PolicyViolation`, audit log completeness), and session trace behavior (workspace/run isolation, distinct session IDs, step lifecycle, artifact attachment, failed/denied step collection, replay plan ordering, and the `to_dict()` serialization shape). All 22 pass locally.

## Out of scope / follow-up

This PR deliberately does **not** implement:
- The actual browser automation runtime (Playwright/Selenium driver, page navigation, form filling, screenshot capture, DOM extraction) — `browser_policy.py` defines the safety/trace contract that such a driver would call into.
- Isolated session/process management (containerized or per-run browser contexts).
- Credential injection / secrets handling for logging into third-party sites.
- Persisting traces to the database (currently in-memory `to_dict()` only) — would need a new SQLAlchemy model in `database/models.py` plus an API blueprint (`/api/browser-sessions/...`) for the frontend to query traces and trigger replays.
- Wiring this policy into the existing tool-calling agents (`agents/autonomous_agent.py`) as new tools (e.g. `browser_navigate`, `browser_click`, `browser_submit_form`).
- Retry/replay execution itself (`replay_plan()` only returns the plan; nothing re-runs it yet).
- Frontend UI for reviewing traces, screenshots, and approving gated submit/destructive actions.

## Test plan

- [x] `python3 -m pytest backend/tests/test_browser_policy.py -v` — 22/22 passed
- [x] Confirmed no impact on existing tests that can run in this environment (`test_config.py`)
- [ ] CI backend job (ruff/mypy/pytest with full deps installed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDp718wense5Kj6ZS2x68P)_