### PR TITLE
Add opportunity ingestion and qualification scoring API

### DIFF
--- a/packages/backend/api_endpoints/opportunities/handler.py
+++ b/packages/backend/api_endpoints/opportunities/handler.py
@@ -1,0 +1,172 @@
+"""Opportunity ingestion, qualification scoring, and review-state tracking.
+
+This is the ingestion + qualification slice of the autonomous proposal/RFP
+workflow described in GitHub issue #143. It lets a user (or an upstream
+portal/inbox connector) submit candidate opportunities, scores them against
+a company profile, tracks simple review states and reviewer comments, and
+flags missing information before a submission attempt.
+
+Draft generation, citation linking to evidence/knowledge assets, and portal
+submission tracking are out of scope for this slice (see PR description).
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from services.opportunity_scoring import missing_fields, score_opportunity
+
+opportunities_bp = Blueprint("opportunities", __name__, url_prefix="/api/opportunities")
+
+REVIEW_STATES = ("new", "qualifying", "in_review", "approved", "rejected", "submitted")
+
+# In-memory stores, mirroring the pattern used by api_endpoints/workspaces.
+_opportunities: dict[str, dict[str, Any]] = {}
+_profiles: dict[str, dict[str, Any]] = {}  # keyed by user identity
+
+
+@opportunities_bp.post("")
+@jwt_required()
+def create_opportunity() -> tuple:  # type: ignore[type-arg]
+    """Ingest a new opportunity (from manual entry, a portal, or an inbox connector)."""
+    data = request.get_json(silent=True) or {}
+    title = (data.get("title") or "").strip()
+    if not title:
+        return jsonify({"error": "title is required"}), 400
+
+    user_id = get_jwt_identity()
+    opp_id = str(uuid.uuid4())
+    opportunity = {
+        "id": opp_id,
+        "userId": user_id,
+        "title": title,
+        "agency": (data.get("agency") or "").strip(),
+        "description": (data.get("description") or "").strip(),
+        "deadline": data.get("deadline"),
+        "budget": data.get("budget"),
+        "tags": data.get("tags") or [],
+        "source": data.get("source", "manual"),
+        "reviewState": "new",
+        "reviewerComments": [],
+        "blockers": [],
+        "score": None,
+    }
+    _opportunities[opp_id] = opportunity
+    return jsonify(opportunity), 201
+
+
+@opportunities_bp.get("")
+@jwt_required()
+def list_opportunities() -> tuple:  # type: ignore[type-arg]
+    """List opportunities for the current user, optionally filtered by review state."""
+    user_id = get_jwt_identity()
+    state_filter = request.args.get("reviewState")
+    results = [
+        o for o in _opportunities.values()
+        if o["userId"] == user_id and (state_filter is None or o["reviewState"] == state_filter)
+    ]
+    return jsonify({"opportunities": results}), 200
+
+
+@opportunities_bp.get("/<opp_id>")
+@jwt_required()
+def get_opportunity(opp_id: str) -> tuple:  # type: ignore[type-arg]
+    opp = _opportunities.get(opp_id)
+    if not opp or opp["userId"] != get_jwt_identity():
+        return jsonify({"error": "Opportunity not found"}), 404
+    return jsonify(opp), 200
+
+
+@opportunities_bp.delete("/<opp_id>")
+@jwt_required()
+def delete_opportunity(opp_id: str) -> tuple:  # type: ignore[type-arg]
+    opp = _opportunities.get(opp_id)
+    if not opp or opp["userId"] != get_jwt_identity():
+        return jsonify({"error": "Opportunity not found"}), 404
+    del _opportunities[opp_id]
+    return jsonify({"deleted": True}), 200
+
+
+@opportunities_bp.put("/profile")
+@jwt_required()
+def set_profile() -> tuple:  # type: ignore[type-arg]
+    """Set the company profile used to qualify opportunities (capabilities, budget range)."""
+    data = request.get_json(silent=True) or {}
+    user_id = get_jwt_identity()
+    profile = {
+        "capabilities": data.get("capabilities") or [],
+        "minBudget": data.get("minBudget"),
+        "maxBudget": data.get("maxBudget"),
+    }
+    _profiles[user_id] = profile
+    return jsonify(profile), 200
+
+
+@opportunities_bp.get("/profile")
+@jwt_required()
+def get_profile() -> tuple:  # type: ignore[type-arg]
+    user_id = get_jwt_identity()
+    return jsonify(_profiles.get(user_id, {"capabilities": [], "minBudget": None, "maxBudget": None})), 200
+
+
+@opportunities_bp.post("/<opp_id>/score")
+@jwt_required()
+def score(opp_id: str) -> tuple:  # type: ignore[type-arg]
+    """Score an opportunity against the company profile, deadline, and budget fit."""
+    user_id = get_jwt_identity()
+    opp = _opportunities.get(opp_id)
+    if not opp or opp["userId"] != user_id:
+        return jsonify({"error": "Opportunity not found"}), 404
+
+    profile = _profiles.get(user_id, {})
+    result = score_opportunity(opp, profile)
+    opp["score"] = result["score"]
+    opp["blockers"] = result["missingFields"]
+    opp["reviewState"] = "qualifying" if opp["reviewState"] == "new" else opp["reviewState"]
+    return jsonify({"opportunity": opp, "scoring": result}), 200
+
+
+@opportunities_bp.post("/<opp_id>/review")
+@jwt_required()
+def update_review(opp_id: str) -> tuple:  # type: ignore[type-arg]
+    """Transition review state and/or attach a reviewer comment."""
+    opp = _opportunities.get(opp_id)
+    if not opp or opp["userId"] != get_jwt_identity():
+        return jsonify({"error": "Opportunity not found"}), 404
+
+    data = request.get_json(silent=True) or {}
+    new_state = data.get("reviewState")
+    comment = data.get("comment")
+
+    if new_state is not None:
+        if new_state not in REVIEW_STATES:
+            return jsonify({"error": f"reviewState must be one of {REVIEW_STATES}"}), 400
+        if new_state == "submitted":
+            blockers = missing_fields(opp)
+            if blockers:
+                return jsonify({
+                    "error": "Cannot mark as submitted — required information is missing",
+                    "missingFields": blockers,
+                }), 422
+        opp["reviewState"] = new_state
+
+    if comment:
+        opp["reviewerComments"].append({
+            "author": get_jwt_identity(),
+            "comment": str(comment),
+        })
+
+    return jsonify(opp), 200
+
+
+@opportunities_bp.get("/<opp_id>/blockers")
+@jwt_required()
+def get_blockers(opp_id: str) -> tuple:  # type: ignore[type-arg]
+    """Flag missing information that would block a submission attempt."""
+    opp = _opportunities.get(opp_id)
+    if not opp or opp["userId"] != get_jwt_identity():
+        return jsonify({"error": "Opportunity not found"}), 404
+    return jsonify({"blockers": missing_fields(opp)}), 200

--- a/packages/backend/app.py
+++ b/packages/backend/app.py
@@ -10,6 +10,7 @@ from flask_jwt_extended import JWTManager
 from api_endpoints.auth.handler import auth_bp
 from api_endpoints.chat.handler import chat_bp
 from api_endpoints.documents.handler import documents_bp
+from api_endpoints.opportunities.handler import opportunities_bp
 from api_endpoints.payments.handler import payments_bp
 from api_endpoints.search.handler import search_bp
 from api_endpoints.user.handler import user_bp
@@ -45,6 +46,7 @@ def create_app(config: dict | None = None) -> Flask:
     app.register_blueprint(auth_bp)
     app.register_blueprint(chat_bp)
     app.register_blueprint(documents_bp)
+    app.register_blueprint(opportunities_bp)
     app.register_blueprint(search_bp)
     app.register_blueprint(user_bp)
     app.register_blueprint(payments_bp)

--- a/packages/backend/services/opportunity_scoring.py
+++ b/packages/backend/services/opportunity_scoring.py
@@ -1,0 +1,125 @@
+"""Scoring logic for proposal/RFP opportunities.
+
+Scores an opportunity against a company profile, deadline proximity, and
+budget fit, and flags missing information that would block a submission.
+This is the first slice of the larger autonomous proposal/RFP workflow
+(see GitHub issue #143): opportunity ingestion + qualification scoring.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+# Required fields an opportunity must have before it can be submitted.
+REQUIRED_SUBMISSION_FIELDS = ("title", "agency", "deadline", "budget", "description")
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%S.%f"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _score_keyword_fit(opportunity: dict[str, Any], profile: dict[str, Any]) -> float:
+    """Score 0-1 overlap between opportunity text and profile keywords/capabilities."""
+    capabilities = [c.lower() for c in profile.get("capabilities", [])]
+    if not capabilities:
+        return 0.5  # neutral when no profile keywords configured
+
+    text = " ".join(
+        str(opportunity.get(field, "")) for field in ("title", "description", "tags")
+    ).lower()
+    if not text.strip():
+        return 0.0
+
+    matches = sum(1 for cap in capabilities if cap in text)
+    return min(1.0, matches / len(capabilities))
+
+
+def _score_deadline(opportunity: dict[str, Any], today: date | None = None) -> float:
+    """Score 0-1 based on how much runway remains before the deadline."""
+    today = today or date.today()
+    deadline = _parse_date(opportunity.get("deadline"))
+    if deadline is None:
+        return 0.0
+    days_left = (deadline - today).days
+    if days_left < 0:
+        return 0.0
+    if days_left >= 30:
+        return 1.0
+    if days_left == 0:
+        return 0.05
+    return round(days_left / 30, 4)
+
+
+def _score_budget_fit(opportunity: dict[str, Any], profile: dict[str, Any]) -> float:
+    """Score 0-1 based on whether opportunity budget falls in the company's target range."""
+    budget = opportunity.get("budget")
+    min_budget = profile.get("minBudget")
+    max_budget = profile.get("maxBudget")
+    if budget is None or (min_budget is None and max_budget is None):
+        return 0.5  # neutral when data is insufficient
+    try:
+        budget = float(budget)
+    except (TypeError, ValueError):
+        return 0.0
+    if min_budget is not None and budget < float(min_budget):
+        return 0.2
+    if max_budget is not None and budget > float(max_budget):
+        return 0.3
+    return 1.0
+
+
+def missing_fields(opportunity: dict[str, Any]) -> list[str]:
+    """Return required submission fields that are missing or empty."""
+    missing = []
+    for field in REQUIRED_SUBMISSION_FIELDS:
+        value = opportunity.get(field)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            missing.append(field)
+    return missing
+
+
+def score_opportunity(
+    opportunity: dict[str, Any],
+    profile: dict[str, Any] | None = None,
+    today: date | None = None,
+) -> dict[str, Any]:
+    """Score an opportunity against company profile, deadline, and budget fit.
+
+    Returns a dict with the overall score (0-100), a breakdown of the
+    sub-scores, a qualification verdict, and any missing fields that would
+    block a submission attempt.
+    """
+    profile = profile or {}
+
+    fit_score = _score_keyword_fit(opportunity, profile)
+    deadline_score = _score_deadline(opportunity, today)
+    budget_score = _score_budget_fit(opportunity, profile)
+
+    weights = {"fit": 0.5, "deadline": 0.25, "budget": 0.25}
+    overall = (
+        fit_score * weights["fit"]
+        + deadline_score * weights["deadline"]
+        + budget_score * weights["budget"]
+    )
+    overall_pct = round(overall * 100, 2)
+
+    missing = missing_fields(opportunity)
+    qualifies = overall_pct >= 50 and deadline_score > 0 and not missing
+
+    return {
+        "score": overall_pct,
+        "breakdown": {
+            "fit": round(fit_score * 100, 2),
+            "deadline": round(deadline_score * 100, 2),
+            "budget": round(budget_score * 100, 2),
+        },
+        "qualifies": qualifies,
+        "missingFields": missing,
+    }

--- a/packages/backend/tests/test_opportunities.py
+++ b/packages/backend/tests/test_opportunities.py
@@ -1,0 +1,174 @@
+"""Tests for opportunity ingestion, scoring, and review-state endpoints."""
+from datetime import date, timedelta
+
+
+def _create_opportunity(client, auth_headers, **overrides):
+    payload = {
+        "title": "City of Springfield Road Maintenance RFP",
+        "agency": "City of Springfield",
+        "description": "Road maintenance and pothole repair services.",
+        "deadline": (date.today() + timedelta(days=20)).isoformat(),
+        "budget": 50000,
+        "tags": ["construction", "maintenance"],
+    }
+    payload.update(overrides)
+    return client.post("/api/opportunities", json=payload, headers=auth_headers)
+
+
+def test_create_opportunity_requires_auth(client):
+    resp = client.post("/api/opportunities", json={"title": "x"})
+    assert resp.status_code == 401
+
+
+def test_create_opportunity_requires_title(client, auth_headers):
+    resp = client.post("/api/opportunities", json={}, headers=auth_headers)
+    assert resp.status_code == 400
+
+
+def test_create_and_list_opportunity(client, auth_headers):
+    resp = _create_opportunity(client, auth_headers)
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body["reviewState"] == "new"
+    assert body["title"] == "City of Springfield Road Maintenance RFP"
+
+    listed = client.get("/api/opportunities", headers=auth_headers)
+    assert listed.status_code == 200
+    assert any(o["id"] == body["id"] for o in listed.get_json()["opportunities"])
+
+
+def test_get_and_delete_opportunity(client, auth_headers):
+    created = _create_opportunity(client, auth_headers).get_json()
+    opp_id = created["id"]
+
+    got = client.get(f"/api/opportunities/{opp_id}", headers=auth_headers)
+    assert got.status_code == 200
+
+    deleted = client.delete(f"/api/opportunities/{opp_id}", headers=auth_headers)
+    assert deleted.status_code == 200
+
+    missing = client.get(f"/api/opportunities/{opp_id}", headers=auth_headers)
+    assert missing.status_code == 404
+
+
+def test_get_opportunity_not_found(client, auth_headers):
+    resp = client.get("/api/opportunities/does-not-exist", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_profile_set_and_get(client, auth_headers):
+    set_resp = client.put(
+        "/api/opportunities/profile",
+        json={"capabilities": ["construction", "roads"], "minBudget": 10000, "maxBudget": 200000},
+        headers=auth_headers,
+    )
+    assert set_resp.status_code == 200
+
+    get_resp = client.get("/api/opportunities/profile", headers=auth_headers)
+    assert get_resp.status_code == 200
+    assert "construction" in get_resp.get_json()["capabilities"]
+
+
+def test_score_opportunity_qualifies_with_good_fit(client, auth_headers):
+    client.put(
+        "/api/opportunities/profile",
+        json={"capabilities": ["construction", "maintenance"], "minBudget": 1000, "maxBudget": 100000},
+        headers=auth_headers,
+    )
+    created = _create_opportunity(client, auth_headers).get_json()
+    resp = client.post(f"/api/opportunities/{created['id']}/score", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["scoring"]["qualifies"] is True
+    assert body["scoring"]["score"] > 50
+    assert body["opportunity"]["reviewState"] == "qualifying"
+
+
+def test_score_opportunity_flags_missing_fields(client, auth_headers):
+    created = _create_opportunity(client, auth_headers, budget=None, description="").get_json()
+    resp = client.post(f"/api/opportunities/{created['id']}/score", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "budget" in body["scoring"]["missingFields"]
+    assert "description" in body["scoring"]["missingFields"]
+    assert body["scoring"]["qualifies"] is False
+
+
+def test_score_opportunity_past_deadline_scores_zero_deadline(client, auth_headers):
+    created = _create_opportunity(
+        client, auth_headers, deadline=(date.today() - timedelta(days=5)).isoformat()
+    ).get_json()
+    resp = client.post(f"/api/opportunities/{created['id']}/score", headers=auth_headers)
+    body = resp.get_json()
+    assert body["scoring"]["breakdown"]["deadline"] == 0
+    assert body["scoring"]["qualifies"] is False
+
+
+def test_score_opportunity_not_found(client, auth_headers):
+    resp = client.post("/api/opportunities/nope/score", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_update_review_state(client, auth_headers):
+    created = _create_opportunity(client, auth_headers).get_json()
+    resp = client.post(
+        f"/api/opportunities/{created['id']}/review",
+        json={"reviewState": "in_review", "comment": "Looks promising, need budget confirmation."},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["reviewState"] == "in_review"
+    assert len(body["reviewerComments"]) == 1
+
+
+def test_update_review_invalid_state(client, auth_headers):
+    created = _create_opportunity(client, auth_headers).get_json()
+    resp = client.post(
+        f"/api/opportunities/{created['id']}/review",
+        json={"reviewState": "bogus"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_cannot_submit_with_missing_fields(client, auth_headers):
+    created = _create_opportunity(client, auth_headers, budget=None).get_json()
+    resp = client.post(
+        f"/api/opportunities/{created['id']}/review",
+        json={"reviewState": "submitted"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+    assert "budget" in resp.get_json()["missingFields"]
+
+
+def test_can_submit_when_complete(client, auth_headers):
+    created = _create_opportunity(client, auth_headers).get_json()
+    resp = client.post(
+        f"/api/opportunities/{created['id']}/review",
+        json={"reviewState": "submitted"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["reviewState"] == "submitted"
+
+
+def test_get_blockers(client, auth_headers):
+    created = _create_opportunity(client, auth_headers, agency="").get_json()
+    resp = client.get(f"/api/opportunities/{created['id']}/blockers", headers=auth_headers)
+    assert resp.status_code == 200
+    assert "agency" in resp.get_json()["blockers"]
+
+
+def test_list_filters_by_review_state(client, auth_headers):
+    _create_opportunity(client, auth_headers, title="Opp A")
+    second = _create_opportunity(client, auth_headers, title="Opp B").get_json()
+    client.post(
+        f"/api/opportunities/{second['id']}/review",
+        json={"reviewState": "approved"},
+        headers=auth_headers,
+    )
+    resp = client.get("/api/opportunities?reviewState=approved", headers=auth_headers)
+    titles = [o["title"] for o in resp.get_json()["opportunities"]]
+    assert titles == ["Opp B"]

--- a/packages/backend/tests/test_opportunity_scoring.py
+++ b/packages/backend/tests/test_opportunity_scoring.py
@@ -1,0 +1,70 @@
+"""Unit tests for services/opportunity_scoring.py."""
+from datetime import date, timedelta
+
+from services.opportunity_scoring import missing_fields, score_opportunity
+
+
+def _opp(**overrides):
+    base = {
+        "title": "Road Maintenance RFP",
+        "agency": "City of Springfield",
+        "description": "Pothole repair and road maintenance services.",
+        "deadline": (date.today() + timedelta(days=15)).isoformat(),
+        "budget": 50000,
+        "tags": ["construction"],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_missing_fields_all_present():
+    assert missing_fields(_opp()) == []
+
+
+def test_missing_fields_detects_blank_and_none():
+    opp = _opp(budget=None, description="   ")
+    missing = missing_fields(opp)
+    assert "budget" in missing
+    assert "description" in missing
+    assert "title" not in missing
+
+
+def test_score_opportunity_good_match_qualifies():
+    profile = {"capabilities": ["construction", "roads"], "minBudget": 1000, "maxBudget": 100000}
+    result = score_opportunity(_opp(), profile)
+    assert result["qualifies"] is True
+    assert result["score"] > 50
+    assert result["missingFields"] == []
+
+
+def test_score_opportunity_no_profile_is_neutral_but_not_blocked_by_fit():
+    result = score_opportunity(_opp(), {})
+    # fit defaults neutral (0.5), deadline/budget also default reasonably
+    assert 0 <= result["score"] <= 100
+
+
+def test_score_opportunity_budget_out_of_range_lowers_score():
+    profile = {"capabilities": ["construction"], "minBudget": 100000, "maxBudget": 500000}
+    result = score_opportunity(_opp(budget=50000), profile)
+    assert result["breakdown"]["budget"] < 100
+
+
+def test_score_opportunity_expired_deadline_never_qualifies():
+    profile = {"capabilities": ["construction"], "minBudget": 0, "maxBudget": 1000000}
+    expired = _opp(deadline=(date.today() - timedelta(days=1)).isoformat())
+    result = score_opportunity(expired, profile)
+    assert result["breakdown"]["deadline"] == 0
+    assert result["qualifies"] is False
+
+
+def test_score_opportunity_missing_deadline_scores_zero_deadline():
+    profile = {"capabilities": ["construction"]}
+    result = score_opportunity(_opp(deadline=None), profile)
+    assert result["breakdown"]["deadline"] == 0
+
+
+def test_score_opportunity_flags_missing_fields_blocks_qualification():
+    profile = {"capabilities": ["construction"], "minBudget": 0, "maxBudget": 1000000}
+    result = score_opportunity(_opp(agency=""), profile)
+    assert "agency" in result["missingFields"]
+    assert result["qualifies"] is False


### PR DESCRIPTION
Addresses #143

## What this implements

This is the first slice of the autonomous proposal/RFP workflow epic. It adds a new `/api/opportunities` blueprint to the Flask backend (`packages/backend/`) covering **opportunity ingestion** and **qualification scoring**, two of the four scope items in the epic:

- **Ingestion**: `POST /api/opportunities` lets a user (or, in the future, an upstream portal/inbox connector) submit a candidate opportunity with title, agency, description, deadline, budget, and tags.
- **Company profile**: `PUT /api/opportunities/profile` / `GET /api/opportunities/profile` let a user configure capability keywords and target budget range used for scoring.
- **Qualification scoring**: `POST /api/opportunities/<id>/score` scores an opportunity 0–100 against the company profile using three weighted sub-scores (capability fit, deadline proximity, budget fit), implemented in `packages/backend/services/opportunity_scoring.py`. Returns a breakdown and a `qualifies` boolean.
- **Review state tracking**: `POST /api/opportunities/<id>/review` transitions an opportunity through `new → qualifying → in_review → approved/rejected → submitted` and supports attaching reviewer comments.
- **Submission guard**: attempting to transition to `submitted` is rejected (422) with the list of missing required fields if the opportunity is incomplete — satisfying the "system flags missing information before a submission attempt" acceptance criterion. There's also a dedicated `GET /api/opportunities/<id>/blockers` endpoint for checking this without attempting a transition.
- `GET /api/opportunities` lists a user's opportunities, optionally filtered by `reviewState`.

All endpoints are JWT-protected (`@jwt_required()`) and scoped per-user, following the existing pattern used by `api_endpoints/workspaces` (in-memory store) and `api_endpoints/documents`.

### Files changed
- `packages/backend/api_endpoints/opportunities/handler.py` (new) — blueprint with ingestion, profile, scoring, review-state, and blockers endpoints
- `packages/backend/services/opportunity_scoring.py` (new) — scoring logic (capability fit / deadline / budget) and `missing_fields()` helper
- `packages/backend/app.py` — registers the new blueprint
- `packages/backend/tests/test_opportunities.py` (new) — 16 endpoint tests (auth, CRUD, scoring, review transitions, submission guard, filtering)
- `packages/backend/tests/test_opportunity_scoring.py` (new) — 8 unit tests for the scoring service

All 24 new tests pass, plus the full existing backend suite (93 passed; 11 pre-existing failures in `test_coverage_boost.py` are unrelated — they fail due to a missing `anthropic` package in the lint/test venv I used, not anything touched here). `ruff check` is clean on all new/modified files.

## Out of scope / left for follow-up

Per the epic's scope, the following are **not** part of this PR:
- Automated opportunity ingestion from external portals, inboxes, or uploaded documents (only manual/API ingestion is implemented; `source` field is present on the model to support this later)
- Draft response generation, citation linking to source evidence, and reusable answer-library integration
- Deadline reminder notifications (the deadline field and scoring exist, but no notification/alerting mechanism)
- Portal submission tracking (the `submitted` review state exists, but there's no integration with actual external portals)
- Persistent storage — opportunities and profiles are stored in-memory (same pattern as `workspaces`), not yet backed by MySQL/`schema.sql`
- Frontend UI for any of the above


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDp718wense5Kj6ZS2x68P)_