### PR TITLE
Add content calendar planning and channel constraint enforcement

### DIFF
--- a/backend/services/social_content_planner.py
+++ b/backend/services/social_content_planner.py
@@ -1,0 +1,375 @@
+"""Social media content planning and channel-constraint enforcement.
+
+This module implements a scoped slice of the "autonomous social media
+workflow" epic (see GitHub issue #142):
+
+- Build a planned content queue ("content calendar") from a posting goal,
+  a cadence, and a list of channels.
+- Define per-channel formatting/scheduling constraints (character limits,
+  allowed media types, posting windows, approval requirements).
+- Define a brand voice profile with hard constraints (prohibited claims /
+  topics) that every draft must be checked against before it is allowed
+  to publish.
+- Track the lifecycle of a planned post (draft -> scheduled -> published /
+  blocked / failed) and produce actionable retry guidance when a post is
+  blocked or fails to publish.
+
+Out of scope for this slice (left for follow-up, see PR description):
+source collection / drafting via an LLM, real channel API integrations,
+engagement metric ingestion, and the operator console UI.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Optional
+
+
+class Channel(str, Enum):
+    TWITTER = "twitter"
+    LINKEDIN = "linkedin"
+    INSTAGRAM = "instagram"
+    FACEBOOK = "facebook"
+
+
+class PostStatus(str, Enum):
+    DRAFT = "draft"
+    PENDING_APPROVAL = "pending_approval"
+    SCHEDULED = "scheduled"
+    PUBLISHED = "published"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class ChannelConstraints:
+    """Channel-specific formatting and scheduling rules."""
+
+    channel: Channel
+    max_chars: int
+    allowed_media_types: tuple[str, ...] = ()
+    max_media_attachments: int = 0
+    requires_approval: bool = False
+    # Allowed posting windows expressed as (start_hour, end_hour) in UTC,
+    # using a 24h clock. Empty tuple means "no restriction".
+    posting_windows: tuple[tuple[int, int], ...] = ()
+
+
+# Default constraints per supported channel. Callers may override by
+# passing their own ChannelConstraints into the planner.
+DEFAULT_CHANNEL_CONSTRAINTS: dict[Channel, ChannelConstraints] = {
+    Channel.TWITTER: ChannelConstraints(
+        channel=Channel.TWITTER,
+        max_chars=280,
+        allowed_media_types=("image", "gif", "video"),
+        max_media_attachments=4,
+        requires_approval=False,
+        posting_windows=((0, 24),),
+    ),
+    Channel.LINKEDIN: ChannelConstraints(
+        channel=Channel.LINKEDIN,
+        max_chars=3000,
+        allowed_media_types=("image", "video", "document"),
+        max_media_attachments=9,
+        requires_approval=True,
+        posting_windows=((13, 18),),
+    ),
+    Channel.INSTAGRAM: ChannelConstraints(
+        channel=Channel.INSTAGRAM,
+        max_chars=2200,
+        allowed_media_types=("image", "video"),
+        max_media_attachments=10,
+        requires_approval=True,
+        posting_windows=((11, 22),),
+    ),
+    Channel.FACEBOOK: ChannelConstraints(
+        channel=Channel.FACEBOOK,
+        max_chars=63206,
+        allowed_media_types=("image", "video", "link"),
+        max_media_attachments=10,
+        requires_approval=False,
+        posting_windows=((0, 24),),
+    ),
+}
+
+
+@dataclass(frozen=True)
+class BrandVoiceProfile:
+    """Hard constraints that every draft must satisfy before publish."""
+
+    name: str
+    prohibited_terms: tuple[str, ...] = ()
+    prohibited_topics: tuple[str, ...] = ()
+    required_disclaimers: tuple[str, ...] = ()
+
+    def violations(self, text: str) -> list[str]:
+        """Return a list of human-readable violation descriptions, if any."""
+        lowered = text.lower()
+        problems: list[str] = []
+        for term in self.prohibited_terms:
+            if term.lower() in lowered:
+                problems.append(f"prohibited term detected: '{term}'")
+        for topic in self.prohibited_topics:
+            if topic.lower() in lowered:
+                problems.append(f"prohibited topic detected: '{topic}'")
+        for disclaimer in self.required_disclaimers:
+            if disclaimer.lower() not in lowered:
+                problems.append(f"missing required disclaimer: '{disclaimer}'")
+        return problems
+
+
+@dataclass
+class PlannedPost:
+    """A single planned item in the content calendar."""
+
+    id: str
+    channel: Channel
+    text: str
+    scheduled_for: datetime
+    media_types: tuple[str, ...] = ()
+    status: PostStatus = PostStatus.DRAFT
+    blocked_reasons: list[str] = field(default_factory=list)
+    retry_guidance: Optional[str] = None
+    published_at: Optional[datetime] = None
+    engagement: dict = field(default_factory=dict)
+
+
+def _next_window_start(scheduled_for: datetime, windows: tuple[tuple[int, int], ...]) -> datetime:
+    """Return the next datetime that falls within one of the given windows."""
+    if not windows:
+        return scheduled_for
+    for start_hour, end_hour in sorted(windows):
+        if start_hour <= scheduled_for.hour < end_hour:
+            return scheduled_for
+    # Move to the start of the next available window, today or tomorrow.
+    candidates = []
+    for start_hour, _ in windows:
+        candidate = scheduled_for.replace(hour=start_hour, minute=0, second=0, microsecond=0)
+        if candidate <= scheduled_for:
+            candidate += timedelta(days=1)
+        candidates.append(candidate)
+    return min(candidates)
+
+
+def check_channel_constraints(
+    text: str,
+    channel: Channel,
+    media_types: tuple[str, ...] = (),
+    constraints: Optional[ChannelConstraints] = None,
+) -> list[str]:
+    """Validate a draft against channel-specific formatting rules.
+
+    Returns a list of violation strings (empty list means the draft is
+    compliant with formatting/media rules for the channel).
+    """
+    rules = constraints or DEFAULT_CHANNEL_CONSTRAINTS[channel]
+    violations: list[str] = []
+
+    if len(text) > rules.max_chars:
+        violations.append(
+            f"text exceeds {rules.channel.value} character limit "
+            f"({len(text)} > {rules.max_chars})"
+        )
+    if not text.strip():
+        violations.append("text is empty")
+
+    if len(media_types) > rules.max_media_attachments:
+        violations.append(
+            f"too many media attachments for {rules.channel.value} "
+            f"({len(media_types)} > {rules.max_media_attachments})"
+        )
+    for media_type in media_types:
+        if rules.allowed_media_types and media_type not in rules.allowed_media_types:
+            violations.append(
+                f"media type '{media_type}' not supported on {rules.channel.value}"
+            )
+
+    return violations
+
+
+def build_retry_guidance(reasons: list[str], channel: Channel) -> str:
+    """Produce actionable, human-readable guidance for a blocked/failed post."""
+    rules = DEFAULT_CHANNEL_CONSTRAINTS[channel]
+    tips: list[str] = []
+    for reason in reasons:
+        if "character limit" in reason:
+            tips.append(f"Shorten the text to {rules.max_chars} characters or fewer.")
+        elif "media type" in reason:
+            tips.append(
+                f"Remove or swap unsupported media; {rules.channel.value} allows: "
+                f"{', '.join(rules.allowed_media_types) or 'no media'}."
+            )
+        elif "too many media attachments" in reason:
+            tips.append(f"Reduce attachments to {rules.max_media_attachments} or fewer.")
+        elif "prohibited term" in reason or "prohibited topic" in reason:
+            tips.append("Remove or rephrase the flagged term/topic and resubmit for review.")
+        elif "missing required disclaimer" in reason:
+            tips.append("Add the required disclaimer text before resubmitting.")
+        elif "empty" in reason:
+            tips.append("Add draft text before scheduling.")
+        elif "awaiting required approval" in reason:
+            tips.append("Get operator approval before this post can publish.")
+        else:
+            tips.append(f"Resolve: {reason}.")
+    return " ".join(tips) if tips else "Resolve the reported issues and resubmit."
+
+
+class ContentCalendarPlanner:
+    """Builds and manages a queue of planned social posts."""
+
+    def __init__(
+        self,
+        brand_voice: BrandVoiceProfile,
+        channel_constraints: Optional[dict[Channel, ChannelConstraints]] = None,
+    ):
+        self.brand_voice = brand_voice
+        self.channel_constraints = channel_constraints or DEFAULT_CHANNEL_CONSTRAINTS
+        self._posts: dict[str, PlannedPost] = {}
+        self._next_id = 1
+
+    def _allocate_id(self) -> str:
+        post_id = f"post-{self._next_id}"
+        self._next_id += 1
+        return post_id
+
+    def plan_queue(
+        self,
+        drafts: list[dict],
+        start: datetime,
+        cadence: timedelta = timedelta(days=1),
+    ) -> list[PlannedPost]:
+        """Generate a planned queue of content from a list of draft dicts.
+
+        Each draft dict must contain ``channel`` (str or Channel) and
+        ``text``, and may contain ``media_types`` (iterable of str).
+        Posts are scheduled at ``start``, ``start + cadence``,
+        ``start + 2*cadence``, ... and then snapped forward to the next
+        valid posting window for their channel.
+        """
+        planned: list[PlannedPost] = []
+        for index, draft in enumerate(drafts):
+            channel = Channel(draft["channel"])
+            rules = self.channel_constraints[channel]
+            raw_time = start + cadence * index
+            scheduled_for = _next_window_start(raw_time, rules.posting_windows)
+
+            post = PlannedPost(
+                id=self._allocate_id(),
+                channel=channel,
+                text=draft["text"],
+                scheduled_for=scheduled_for,
+                media_types=tuple(draft.get("media_types", ())),
+                status=(
+                    PostStatus.PENDING_APPROVAL if rules.requires_approval else PostStatus.DRAFT
+                ),
+            )
+            self._posts[post.id] = post
+            planned.append(post)
+        return planned
+
+    def validate_post(self, post: PlannedPost) -> list[str]:
+        """Run all enforcement checks (channel + brand voice) on a post."""
+        rules = self.channel_constraints[post.channel]
+        reasons = check_channel_constraints(
+            post.text, post.channel, post.media_types, rules
+        )
+        reasons.extend(self.brand_voice.violations(post.text))
+        return reasons
+
+    def approve(self, post_id: str) -> PlannedPost:
+        post = self._posts[post_id]
+        if post.status != PostStatus.PENDING_APPROVAL:
+            raise ValueError(f"post {post_id} is not pending approval (status={post.status})")
+        post.status = PostStatus.SCHEDULED
+        return post
+
+    def attempt_publish(self, post_id: str, now: Optional[datetime] = None) -> PlannedPost:
+        """Validate constraints and either publish, block, or mark failed.
+
+        - If channel/brand-voice constraints are violated -> BLOCKED, with
+          retry guidance attached.
+        - If still pending approval -> BLOCKED (approval required).
+        - If the scheduled time is in the future relative to ``now`` -> the
+          post stays unpublished (no state change) since it's not due yet.
+        - Otherwise -> PUBLISHED.
+        """
+        post = self._posts[post_id]
+        now = now or datetime.utcnow()
+
+        reasons = self.validate_post(post)
+        if post.status == PostStatus.PENDING_APPROVAL:
+            reasons = list(reasons) + ["awaiting required approval"]
+
+        if reasons:
+            post.status = PostStatus.BLOCKED
+            post.blocked_reasons = reasons
+            post.retry_guidance = build_retry_guidance(reasons, post.channel)
+            return post
+
+        if post.scheduled_for > now:
+            # Not due yet; leave status untouched.
+            return post
+
+        post.status = PostStatus.PUBLISHED
+        post.published_at = now
+        post.blocked_reasons = []
+        post.retry_guidance = None
+        return post
+
+    def mark_failed(self, post_id: str, error: str) -> PlannedPost:
+        """Record a publish-time failure (e.g. channel API error) with retry guidance."""
+        post = self._posts[post_id]
+        post.status = PostStatus.FAILED
+        post.blocked_reasons = [error]
+        post.retry_guidance = (
+            f"Publish attempt failed: {error}. Verify channel credentials/connectivity "
+            "and retry; if the error persists, escalate to an operator."
+        )
+        return post
+
+    def record_engagement(self, post_id: str, metrics: dict) -> PlannedPost:
+        post = self._posts[post_id]
+        if post.status != PostStatus.PUBLISHED:
+            raise ValueError(f"cannot record engagement for unpublished post {post_id}")
+        post.engagement.update(metrics)
+        return post
+
+    def get_post(self, post_id: str) -> PlannedPost:
+        return self._posts[post_id]
+
+    def queue(self) -> list[PlannedPost]:
+        return sorted(self._posts.values(), key=lambda p: p.scheduled_for)
+
+    def console_summary(self) -> dict:
+        """Operator-console-friendly summary: counts by status + blocked/failed detail."""
+        posts = self.queue()
+        by_status: dict[str, int] = {}
+        for post in posts:
+            by_status[post.status.value] = by_status.get(post.status.value, 0) + 1
+        actionable = [
+            {
+                "id": post.id,
+                "channel": post.channel.value,
+                "status": post.status.value,
+                "reasons": post.blocked_reasons,
+                "retry_guidance": post.retry_guidance,
+            }
+            for post in posts
+            if post.status in (PostStatus.BLOCKED, PostStatus.FAILED)
+        ]
+        published = [
+            {
+                "id": post.id,
+                "channel": post.channel.value,
+                "published_at": post.published_at.isoformat() if post.published_at else None,
+                "engagement": post.engagement,
+            }
+            for post in posts
+            if post.status == PostStatus.PUBLISHED
+        ]
+        return {
+            "counts_by_status": by_status,
+            "actionable": actionable,
+            "published": published,
+        }

--- a/backend/tests/test_social_content_planner.py
+++ b/backend/tests/test_social_content_planner.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from services.social_content_planner import (
+    BrandVoiceProfile,
+    Channel,
+    ChannelConstraints,
+    ContentCalendarPlanner,
+    PostStatus,
+    build_retry_guidance,
+    check_channel_constraints,
+)
+
+
+@pytest.fixture
+def brand_voice() -> BrandVoiceProfile:
+    return BrandVoiceProfile(
+        name="Anote",
+        prohibited_terms=("guaranteed returns",),
+        prohibited_topics=("medical advice",),
+        required_disclaimers=(),
+    )
+
+
+@pytest.fixture
+def planner(brand_voice: BrandVoiceProfile) -> ContentCalendarPlanner:
+    return ContentCalendarPlanner(brand_voice=brand_voice)
+
+
+# ---------------------------------------------------------------------------
+# Channel constraint enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_check_channel_constraints_passes_for_compliant_tweet():
+    violations = check_channel_constraints("Hello world", Channel.TWITTER, ("image",))
+    assert violations == []
+
+
+def test_check_channel_constraints_flags_over_length_text():
+    violations = check_channel_constraints("x" * 281, Channel.TWITTER)
+    assert any("character limit" in v for v in violations)
+
+
+def test_check_channel_constraints_flags_empty_text():
+    violations = check_channel_constraints("   ", Channel.TWITTER)
+    assert any("empty" in v for v in violations)
+
+
+def test_check_channel_constraints_flags_disallowed_media_type():
+    violations = check_channel_constraints("Hi", Channel.TWITTER, ("document",))
+    assert any("not supported" in v for v in violations)
+
+
+def test_check_channel_constraints_flags_too_many_attachments():
+    violations = check_channel_constraints(
+        "Hi", Channel.TWITTER, ("image", "image", "image", "image", "image")
+    )
+    assert any("too many media attachments" in v for v in violations)
+
+
+def test_custom_constraints_override_defaults():
+    custom = ChannelConstraints(channel=Channel.TWITTER, max_chars=5)
+    violations = check_channel_constraints("toolong", Channel.TWITTER, constraints=custom)
+    assert any("character limit" in v for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Brand voice enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_brand_voice_flags_prohibited_term(brand_voice: BrandVoiceProfile):
+    violations = brand_voice.violations("We offer guaranteed returns on investment.")
+    assert any("prohibited term" in v for v in violations)
+
+
+def test_brand_voice_flags_prohibited_topic(brand_voice: BrandVoiceProfile):
+    violations = brand_voice.violations("Here is some medical advice for you.")
+    assert any("prohibited topic" in v for v in violations)
+
+
+def test_brand_voice_requires_disclaimer():
+    voice = BrandVoiceProfile(name="Anote", required_disclaimers=("not financial advice",))
+    violations = voice.violations("Some neutral text.")
+    assert any("missing required disclaimer" in v for v in violations)
+    assert voice.violations("Some text. Not Financial Advice.") == []
+
+
+def test_brand_voice_clean_text_has_no_violations(brand_voice: BrandVoiceProfile):
+    assert brand_voice.violations("A perfectly fine post about our product.") == []
+
+
+# ---------------------------------------------------------------------------
+# Retry guidance
+# ---------------------------------------------------------------------------
+
+
+def test_build_retry_guidance_for_length_violation():
+    guidance = build_retry_guidance(["text exceeds twitter character limit (300 > 280)"], Channel.TWITTER)
+    assert "Shorten the text to 280" in guidance
+
+
+def test_build_retry_guidance_for_prohibited_term():
+    guidance = build_retry_guidance(["prohibited term detected: 'guaranteed returns'"], Channel.TWITTER)
+    assert "Remove or rephrase" in guidance
+
+
+def test_build_retry_guidance_falls_back_for_unknown_reason():
+    guidance = build_retry_guidance(["some unexpected reason"], Channel.TWITTER)
+    assert "Resolve: some unexpected reason." in guidance
+
+
+# ---------------------------------------------------------------------------
+# ContentCalendarPlanner: planning queue
+# ---------------------------------------------------------------------------
+
+
+def test_plan_queue_creates_posts_with_cadence(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)  # within twitter's all-day window
+    drafts = [
+        {"channel": "twitter", "text": "Post one"},
+        {"channel": "twitter", "text": "Post two"},
+    ]
+    posts = planner.plan_queue(drafts, start=start, cadence=timedelta(days=1))
+    assert len(posts) == 2
+    assert posts[0].scheduled_for == start
+    assert posts[1].scheduled_for == start + timedelta(days=1)
+    assert all(p.status == PostStatus.DRAFT for p in posts)
+
+
+def test_plan_queue_marks_approval_required_channels_pending(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 14, 0, 0)  # within linkedin's window
+    drafts = [{"channel": "linkedin", "text": "Professional update"}]
+    posts = planner.plan_queue(drafts, start=start)
+    assert posts[0].status == PostStatus.PENDING_APPROVAL
+
+
+def test_plan_queue_snaps_to_next_posting_window(planner: ContentCalendarPlanner):
+    # LinkedIn's window is 13-18 UTC; scheduling at 02:00 should snap to 13:00 same day.
+    start = datetime(2026, 6, 22, 2, 0, 0)
+    drafts = [{"channel": "linkedin", "text": "Morning post"}]
+    posts = planner.plan_queue(drafts, start=start)
+    assert posts[0].scheduled_for == datetime(2026, 6, 22, 13, 0, 0)
+
+
+def test_plan_queue_snaps_to_next_day_if_window_already_passed(planner: ContentCalendarPlanner):
+    # LinkedIn's window is 13-18 UTC; scheduling at 20:00 should snap to 13:00 next day.
+    start = datetime(2026, 6, 22, 20, 0, 0)
+    drafts = [{"channel": "linkedin", "text": "Evening post"}]
+    posts = planner.plan_queue(drafts, start=start)
+    assert posts[0].scheduled_for == datetime(2026, 6, 23, 13, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# ContentCalendarPlanner: publish lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_attempt_publish_succeeds_for_compliant_due_post(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    posts = planner.plan_queue([{"channel": "twitter", "text": "Hello!"}], start=start)
+    result = planner.attempt_publish(posts[0].id, now=start + timedelta(minutes=1))
+    assert result.status == PostStatus.PUBLISHED
+    assert result.published_at is not None
+    assert result.blocked_reasons == []
+
+
+def test_attempt_publish_not_due_yet_leaves_status_unchanged(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    posts = planner.plan_queue([{"channel": "twitter", "text": "Hello!"}], start=start)
+    result = planner.attempt_publish(posts[0].id, now=start - timedelta(hours=1))
+    assert result.status == PostStatus.DRAFT
+
+
+def test_attempt_publish_blocks_on_channel_violation(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    posts = planner.plan_queue([{"channel": "twitter", "text": "x" * 300}], start=start)
+    result = planner.attempt_publish(posts[0].id, now=start)
+    assert result.status == PostStatus.BLOCKED
+    assert result.retry_guidance is not None
+    assert any("character limit" in r for r in result.blocked_reasons)
+
+
+def test_attempt_publish_blocks_on_brand_voice_violation(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    posts = planner.plan_queue(
+        [{"channel": "twitter", "text": "We offer guaranteed returns!"}], start=start
+    )
+    result = planner.attempt_publish(posts[0].id, now=start)
+    assert result.status == PostStatus.BLOCKED
+    assert any("prohibited term" in r for r in result.blocked_reasons)
+
+
+def test_attempt_publish_blocks_pending_approval_post(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 14, 0, 0)
+    posts = planner.plan_queue([{"channel": "linkedin", "text": "Update"}], start=start)
+    assert posts[0].status == PostStatus.PENDING_APPROVAL
+    result = planner.attempt_publish(posts[0].id, now=start)
+    assert result.status == PostStatus.BLOCKED
+    assert any("awaiting required approval" in r for r in result.blocked_reasons)
+
+
+def test_approve_then_publish_succeeds(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 14, 0, 0)
+    posts = planner.plan_queue([{"channel": "linkedin", "text": "Update"}], start=start)
+    planner.approve(posts[0].id)
+    result = planner.attempt_publish(posts[0].id, now=start)
+    assert result.status == PostStatus.PUBLISHED
+
+
+def test_approve_raises_if_not_pending(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    posts = planner.plan_queue([{"channel": "twitter", "text": "Hello"}], start=start)
+    with pytest.raises(ValueError):
+        planner.approve(posts[0].id)
+
+
+def test_mark_failed_records_retry_guidance(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    posts = planner.plan_queue([{"channel": "twitter", "text": "Hello"}], start=start)
+    result = planner.mark_failed(posts[0].id, "channel API timeout")
+    assert result.status == PostStatus.FAILED
+    assert "channel API timeout" in result.blocked_reasons
+    assert "Verify channel credentials" in result.retry_guidance
+
+
+def test_record_engagement_requires_published_post(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    posts = planner.plan_queue([{"channel": "twitter", "text": "Hello"}], start=start)
+    with pytest.raises(ValueError):
+        planner.record_engagement(posts[0].id, {"likes": 10})
+
+
+def test_record_engagement_on_published_post(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    posts = planner.plan_queue([{"channel": "twitter", "text": "Hello"}], start=start)
+    planner.attempt_publish(posts[0].id, now=start)
+    result = planner.record_engagement(posts[0].id, {"likes": 10, "shares": 2})
+    assert result.engagement == {"likes": 10, "shares": 2}
+
+
+# ---------------------------------------------------------------------------
+# Operator console summary
+# ---------------------------------------------------------------------------
+
+
+def test_console_summary_groups_by_status_and_surfaces_actionable_items(
+    planner: ContentCalendarPlanner,
+):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    posts = planner.plan_queue(
+        [
+            {"channel": "twitter", "text": "Good post"},
+            {"channel": "twitter", "text": "x" * 300},
+        ],
+        start=start,
+    )
+    planner.attempt_publish(posts[0].id, now=start)
+    planner.attempt_publish(posts[1].id, now=start)
+
+    summary = planner.console_summary()
+    assert summary["counts_by_status"]["published"] == 1
+    assert summary["counts_by_status"]["blocked"] == 1
+    assert len(summary["actionable"]) == 1
+    assert summary["actionable"][0]["retry_guidance"]
+    assert len(summary["published"]) == 1
+
+
+def test_queue_returns_posts_sorted_by_scheduled_time(planner: ContentCalendarPlanner):
+    start = datetime(2026, 6, 22, 1, 0, 0)
+    drafts = [
+        {"channel": "twitter", "text": "First"},
+        {"channel": "twitter", "text": "Second"},
+        {"channel": "twitter", "text": "Third"},
+    ]
+    planner.plan_queue(drafts, start=start, cadence=timedelta(hours=2))
+    queued = planner.queue()
+    assert [p.text for p in queued] == ["First", "Second", "Third"]
+    assert queued[0].scheduled_for < queued[1].scheduled_for < queued[2].scheduled_for


### PR DESCRIPTION
Addresses #142

## What this implements

This is a scoped slice of the "autonomous social media workflow" epic. It adds a new backend service module, `backend/services/social_content_planner.py`, with:

- **Content calendar planning** — `ContentCalendarPlanner.plan_queue()` turns a list of draft posts (channel + text + optional media) into a scheduled queue, applying a cadence and snapping each post forward to the next valid posting window for its channel.
- **Channel-specific constraints** — `ChannelConstraints` + `check_channel_constraints()` enforce per-channel character limits, allowed media types, max attachment counts, posting windows, and whether a channel requires approval before publish. Defaults are provided for Twitter, LinkedIn, Instagram, and Facebook (`DEFAULT_CHANNEL_CONSTRAINTS`).
- **Brand voice / hard constraints** — `BrandVoiceProfile` checks drafts for prohibited terms, prohibited topics, and required disclaimers, and reports violations.
- **Post lifecycle tracking** — `PlannedPost` moves through `draft -> pending_approval -> scheduled -> published / blocked / failed`. `attempt_publish()` re-validates channel + brand-voice constraints at publish time and blocks non-compliant or not-yet-approved posts; `mark_failed()` records publish-time failures (e.g. channel API errors).
- **Actionable retry guidance** — `build_retry_guidance()` turns a list of violation reasons into specific, human-readable next steps (e.g. "Shorten the text to 280 characters or fewer.", "Get operator approval before this post can publish.").
- **Operator console summary** — `ContentCalendarPlanner.console_summary()` returns counts by status plus the actionable list of blocked/failed posts (with retry guidance) and the list of published posts (with engagement metrics), in a shape ready for an operator console UI to consume.

Tests: `backend/tests/test_social_content_planner.py` (29 tests) cover channel constraint checks, brand voice enforcement, retry guidance generation, queue planning/scheduling-window snapping, the full publish lifecycle (success, not-yet-due, blocked on channel/brand-voice violations, pending-approval blocking, approve-then-publish, failure + retry guidance, engagement recording), and the console summary. All pass locally; this module has no external dependencies (no Flask/DB/LLM calls), so it runs independently of the rest of the test suite's environment requirements.

## Out of scope / left for follow-up

- Source collection and AI-assisted drafting/revision (LLM-backed content generation).
- Real channel API integrations for publishing (this PR provides the planning/validation/lifecycle layer; an actual publisher would call `attempt_publish`/`mark_failed` after a real API call).
- Asset attachment storage/upload handling (media types are validated by name only here).
- Ingesting real engagement metrics from channel APIs (only a `record_engagement` write path exists).
- Wiring this service into a Flask blueprint / `app.py` and the operator console frontend — `app.py` is a large existing monolith and wiring a new endpoint set into it is left as a follow-up to keep this PR focused and low-risk.
- Persisting planned posts (currently in-memory per `ContentCalendarPlanner` instance); a follow-up should add DB-backed storage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDp718wense5Kj6ZS2x68P)_