### PR TITLE
Add workflow checkpoint/recovery engine (subset of failure recovery epic)

### DIFF
--- a/backend/services/workflow_recovery.py
+++ b/backend/services/workflow_recovery.py
@@ -1,0 +1,431 @@
+"""Workflow / job failure-recovery engine.
+
+This module implements the "Recovery Model" portion of GitHub issue #135
+("Add failure recovery and resume-from-checkpoint for workflows and jobs"):
+
+- Explicit checkpointing of per-step state for a workflow run.
+- Tracking of which step outputs are reusable vs. invalidated after a
+  failure (lineage-aware downstream invalidation).
+- Recovery actions: retry the same step, retry a step with edited inputs,
+  resume from the last good checkpoint, and rerun only downstream tasks.
+- An auditable, append-only history of every recovery action taken on a
+  run, so recovery decisions are traceable.
+
+The engine is intentionally storage-agnostic: it operates on an in-memory
+``WorkflowRun`` aggregate that callers can persist however they like (e.g.
+serialize to a DB row's JSON column, or back it with the ORM models in
+``database/models.py`` in a follow-up). This keeps the core recovery logic
+independently testable without requiring a database, Flask app context, or
+the wider agent stack to be wired up.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class StepStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    INVALIDATED = "invalidated"
+    SKIPPED = "skipped"
+
+
+class RecoveryAction(StrEnum):
+    RETRY_SAME = "retry_same"
+    RETRY_WITH_EDITED_INPUT = "retry_with_edited_input"
+    RESUME_FROM_CHECKPOINT = "resume_from_checkpoint"
+    RERUN_DOWNSTREAM = "rerun_downstream"
+
+
+class WorkflowError(Exception):
+    """Base error for the workflow recovery engine."""
+
+
+class StepNotFoundError(WorkflowError):
+    pass
+
+
+class InvalidRecoveryActionError(WorkflowError):
+    pass
+
+
+def _now() -> float:
+    return time.time()
+
+
+@dataclass
+class StepCheckpoint:
+    """A single recorded checkpoint for a step.
+
+    Checkpoints accumulate over the lifetime of a step (e.g. one per
+    attempt). The latest checkpoint with status SUCCEEDED is what a resume
+    operation will rely on to avoid recomputing the step.
+    """
+
+    step_id: str
+    status: StepStatus
+    inputs: dict[str, Any] = field(default_factory=dict)
+    output: Any = None
+    error: str | None = None
+    attempt: int = 1
+    created_at: float = field(default_factory=_now)
+
+
+@dataclass
+class Step:
+    """A node in the workflow DAG."""
+
+    step_id: str
+    name: str
+    depends_on: list[str] = field(default_factory=list)
+    status: StepStatus = StepStatus.PENDING
+    inputs: dict[str, Any] = field(default_factory=dict)
+    output: Any = None
+    error: str | None = None
+    attempt: int = 0
+    checkpoints: list[StepCheckpoint] = field(default_factory=list)
+
+    def latest_succeeded_checkpoint(self) -> StepCheckpoint | None:
+        for checkpoint in reversed(self.checkpoints):
+            if checkpoint.status == StepStatus.SUCCEEDED:
+                return checkpoint
+        return None
+
+
+@dataclass
+class AuditEntry:
+    """An immutable, append-only audit record of a recovery decision."""
+
+    entry_id: str
+    run_id: str
+    action: RecoveryAction
+    step_id: str
+    actor: str
+    reason: str | None
+    affected_steps: list[str]
+    created_at: float = field(default_factory=_now)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entry_id": self.entry_id,
+            "run_id": self.run_id,
+            "action": self.action.value,
+            "step_id": self.step_id,
+            "actor": self.actor,
+            "reason": self.reason,
+            "affected_steps": list(self.affected_steps),
+            "created_at": self.created_at,
+        }
+
+
+class WorkflowRun:
+    """A single execution of a workflow, with checkpoint/recovery support.
+
+    ``steps`` is an ordered dict-like mapping of step_id -> Step describing
+    the DAG. Edges are expressed via ``Step.depends_on``.
+    """
+
+    def __init__(self, run_id: str | None = None, name: str = "") -> None:
+        self.run_id = run_id or str(uuid.uuid4())
+        self.name = name
+        self.steps: dict[str, Step] = {}
+        self.order: list[str] = []
+        self.audit_log: list[AuditEntry] = []
+
+    # ------------------------------------------------------------------
+    # DAG construction
+    # ------------------------------------------------------------------
+    def add_step(self, step_id: str, name: str, depends_on: list[str] | None = None,
+                 inputs: dict[str, Any] | None = None) -> Step:
+        step = Step(
+            step_id=step_id,
+            name=name,
+            depends_on=list(depends_on or []),
+            inputs=dict(inputs or {}),
+        )
+        self.steps[step_id] = step
+        self.order.append(step_id)
+        return step
+
+    def _get_step(self, step_id: str) -> Step:
+        step = self.steps.get(step_id)
+        if step is None:
+            raise StepNotFoundError(f"Unknown step_id: {step_id!r}")
+        return step
+
+    def downstream_of(self, step_id: str) -> list[str]:
+        """Return all step_ids transitively dependent on ``step_id`` (exclusive)."""
+        self._get_step(step_id)
+        downstream: list[str] = []
+        frontier = {step_id}
+        changed = True
+        while changed:
+            changed = False
+            for sid in self.order:
+                if sid in downstream or sid in frontier:
+                    continue
+                step = self.steps[sid]
+                if any(dep in frontier or dep in downstream for dep in step.depends_on):
+                    downstream.append(sid)
+                    changed = True
+        return downstream
+
+    # ------------------------------------------------------------------
+    # Execution + checkpointing
+    # ------------------------------------------------------------------
+    def run_step(self, step_id: str, executor: Callable[[dict[str, Any]], Any]) -> Step:
+        """Execute a single step with ``executor(inputs) -> output``.
+
+        Records a checkpoint regardless of outcome. Raises nothing — failures
+        are captured on the Step/checkpoint so recovery flows can inspect
+        them rather than relying on exception propagation.
+        """
+        step = self._get_step(step_id)
+
+        unmet = [
+            dep for dep in step.depends_on
+            if self.steps[dep].status != StepStatus.SUCCEEDED
+        ]
+        if unmet:
+            step.status = StepStatus.SKIPPED
+            step.error = f"Unmet dependencies: {unmet}"
+            return step
+
+        step.status = StepStatus.RUNNING
+        step.attempt += 1
+        try:
+            output = executor(step.inputs)
+        except Exception as exc:  # noqa: BLE001 — failures are first-class data here
+            step.status = StepStatus.FAILED
+            step.error = str(exc)
+            step.checkpoints.append(StepCheckpoint(
+                step_id=step_id,
+                status=StepStatus.FAILED,
+                inputs=dict(step.inputs),
+                error=str(exc),
+                attempt=step.attempt,
+            ))
+            self._invalidate_downstream(step_id)
+            return step
+
+        step.status = StepStatus.SUCCEEDED
+        step.output = output
+        step.error = None
+        step.checkpoints.append(StepCheckpoint(
+            step_id=step_id,
+            status=StepStatus.SUCCEEDED,
+            inputs=dict(step.inputs),
+            output=output,
+            attempt=step.attempt,
+        ))
+        return step
+
+    def _invalidate_downstream(self, step_id: str) -> list[str]:
+        """Mark all downstream steps as invalidated after an upstream failure.
+
+        Steps that have not yet run (PENDING) are left untouched — they were
+        never "reusable" to begin with. Only steps that previously succeeded
+        get their reusable output explicitly invalidated, since their output
+        may have been derived from data that is now suspect.
+        """
+        invalidated: list[str] = []
+        for sid in self.downstream_of(step_id):
+            step = self.steps[sid]
+            if step.status == StepStatus.SUCCEEDED:
+                step.status = StepStatus.INVALIDATED
+                invalidated.append(sid)
+        return invalidated
+
+    # ------------------------------------------------------------------
+    # Recovery actions
+    # ------------------------------------------------------------------
+    def _record_audit(self, action: RecoveryAction, step_id: str, actor: str,
+                       reason: str | None, affected_steps: list[str]) -> AuditEntry:
+        entry = AuditEntry(
+            entry_id=str(uuid.uuid4()),
+            run_id=self.run_id,
+            action=action,
+            step_id=step_id,
+            actor=actor,
+            reason=reason,
+            affected_steps=affected_steps,
+        )
+        self.audit_log.append(entry)
+        return entry
+
+    def retry_step(
+        self,
+        step_id: str,
+        executor: Callable[[dict[str, Any]], Any],
+        *,
+        actor: str = "system",
+        reason: str | None = None,
+        edited_inputs: dict[str, Any] | None = None,
+    ) -> Step:
+        """Retry a single failed (or invalidated) step.
+
+        If ``edited_inputs`` is supplied, the step's inputs are updated first
+        (RETRY_WITH_EDITED_INPUT); otherwise the same inputs are reused
+        (RETRY_SAME). On success, downstream steps that were invalidated by
+        this step's prior failure are NOT automatically rerun — call
+        ``rerun_downstream`` explicitly so that decision stays auditable and
+        intentional.
+        """
+        step = self._get_step(step_id)
+        if step.status not in (StepStatus.FAILED, StepStatus.INVALIDATED):
+            raise InvalidRecoveryActionError(
+                f"Cannot retry step {step_id!r} in status {step.status.value!r}; "
+                "only FAILED or INVALIDATED steps may be retried."
+            )
+
+        action = RecoveryAction.RETRY_SAME
+        if edited_inputs is not None:
+            step.inputs.update(edited_inputs)
+            action = RecoveryAction.RETRY_WITH_EDITED_INPUT
+
+        self.run_step(step_id, executor)
+        self._record_audit(action, step_id, actor, reason, affected_steps=[step_id])
+        return step
+
+    def resume_from_checkpoint(
+        self,
+        executors: dict[str, Callable[[dict[str, Any]], Any]],
+        *,
+        actor: str = "system",
+        reason: str | None = None,
+    ) -> list[Step]:
+        """Resume a run, skipping any step that already has a successful
+        checkpoint and is not currently invalidated.
+
+        Returns the list of steps that were (re)executed. Steps that are
+        SUCCEEDED are left untouched (no wasted recomputation); steps that
+        are PENDING, FAILED, or INVALIDATED are executed in dependency
+        order, reusing the last successful checkpoint's inputs when present.
+        """
+        executed: list[Step] = []
+        for step_id in self.order:
+            step = self.steps[step_id]
+            if step.status == StepStatus.SUCCEEDED:
+                continue  # reuse — nothing to do
+
+            checkpoint = step.latest_succeeded_checkpoint()
+            if checkpoint is not None and step.status not in (
+                StepStatus.INVALIDATED, StepStatus.FAILED,
+            ):
+                # A prior successful checkpoint exists, nothing downstream
+                # invalidated it, and the step itself isn't currently
+                # failing — restore the checkpoint rather than recompute.
+                step.status = StepStatus.SUCCEEDED
+                step.output = checkpoint.output
+                step.error = None
+                continue
+
+            executor = executors.get(step_id)
+            if executor is None:
+                continue
+            self.run_step(step_id, executor)
+            executed.append(step)
+
+        affected = [s.step_id for s in executed]
+        self._record_audit(
+            RecoveryAction.RESUME_FROM_CHECKPOINT, step_id="*", actor=actor,
+            reason=reason, affected_steps=affected,
+        )
+        return executed
+
+    def rerun_downstream(
+        self,
+        step_id: str,
+        executors: dict[str, Callable[[dict[str, Any]], Any]],
+        *,
+        actor: str = "system",
+        reason: str | None = None,
+    ) -> list[Step]:
+        """Rerun only the steps downstream of ``step_id`` (exclusive),
+        in dependency order, leaving upstream / unrelated steps untouched.
+
+        Useful for the "edited artifact at a checkpoint" scenario: upstream
+        retrieval steps stay intact while downstream drafting steps redo
+        their work against the new artifact.
+        """
+        self._get_step(step_id)
+        downstream_ids = set(self.downstream_of(step_id))
+        executed: list[Step] = []
+        for sid in self.order:
+            if sid not in downstream_ids:
+                continue
+            step = self.steps[sid]
+            step.status = StepStatus.PENDING
+            executor = executors.get(sid)
+            if executor is None:
+                continue
+            self.run_step(sid, executor)
+            executed.append(step)
+
+        affected = [s.step_id for s in executed]
+        self._record_audit(
+            RecoveryAction.RERUN_DOWNSTREAM, step_id=step_id, actor=actor,
+            reason=reason, affected_steps=affected,
+        )
+        return executed
+
+    # ------------------------------------------------------------------
+    # Introspection / serialization (for the future failure-detail API)
+    # ------------------------------------------------------------------
+    def failing_steps(self) -> list[Step]:
+        return [s for s in self.steps.values() if s.status == StepStatus.FAILED]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "name": self.name,
+            "steps": {
+                sid: {
+                    "step_id": step.step_id,
+                    "name": step.name,
+                    "depends_on": step.depends_on,
+                    "status": step.status.value,
+                    "inputs": step.inputs,
+                    "output": step.output,
+                    "error": step.error,
+                    "attempt": step.attempt,
+                    "checkpoint_count": len(step.checkpoints),
+                }
+                for sid, step in self.steps.items()
+            },
+            "audit_log": [entry.to_dict() for entry in self.audit_log],
+        }
+
+    def failure_detail(self, step_id: str) -> dict[str, Any]:
+        """Build the payload the frontend failure-detail view would render:
+        failing step, error summary, available recovery options, and the
+        list of downstream tasks affected by this failure.
+        """
+        step = self._get_step(step_id)
+        downstream = self.downstream_of(step_id)
+        options = []
+        if step.status in (StepStatus.FAILED, StepStatus.INVALIDATED):
+            options = [
+                RecoveryAction.RETRY_SAME.value,
+                RecoveryAction.RETRY_WITH_EDITED_INPUT.value,
+                RecoveryAction.RESUME_FROM_CHECKPOINT.value,
+                RecoveryAction.RERUN_DOWNSTREAM.value,
+            ]
+        return {
+            "run_id": self.run_id,
+            "step_id": step.step_id,
+            "step_name": step.name,
+            "status": step.status.value,
+            "error": step.error,
+            "attempt": step.attempt,
+            "recovery_options": options,
+            "affected_downstream_steps": downstream,
+        }

--- a/backend/tests/test_workflow_recovery.py
+++ b/backend/tests/test_workflow_recovery.py
@@ -1,0 +1,300 @@
+"""Tests for the workflow/job failure-recovery engine (issue #135).
+
+Covers the acceptance criteria from the issue:
+  * A failed run can resume from a checkpoint rather than restarting.
+  * Completed unaffected steps are not recomputed.
+  * Users can retry a failed step with corrected input.
+  * Recovery actions show up in run history / audit trail.
+  * Downstream invalidation behaves correctly after an upstream failure.
+"""
+from __future__ import annotations
+
+import pytest
+from services.workflow_recovery import (
+    InvalidRecoveryActionError,
+    RecoveryAction,
+    StepNotFoundError,
+    StepStatus,
+    WorkflowRun,
+)
+
+
+def _ok(value):
+    def _executor(_inputs):
+        return value
+    return _executor
+
+
+def _fail(message="boom"):
+    def _executor(_inputs):
+        raise RuntimeError(message)
+    return _executor
+
+
+def _build_linear_run() -> WorkflowRun:
+    """ingest -> transform -> publish"""
+    run = WorkflowRun(name="linear")
+    run.add_step("ingest", "Ingest", inputs={"source": "s3://bucket/file"})
+    run.add_step("transform", "Transform", depends_on=["ingest"], inputs={"mode": "default"})
+    run.add_step("publish", "Publish", depends_on=["transform"], inputs={"target": "webhook"})
+    return run
+
+
+# ---------------------------------------------------------------------------
+# Basic execution + checkpointing
+# ---------------------------------------------------------------------------
+
+
+def test_run_step_records_checkpoint_on_success():
+    run = _build_linear_run()
+    step = run.run_step("ingest", _ok("ingested-data"))
+    assert step.status == StepStatus.SUCCEEDED
+    assert step.output == "ingested-data"
+    assert len(step.checkpoints) == 1
+    assert step.checkpoints[0].status == StepStatus.SUCCEEDED
+
+
+def test_run_step_records_checkpoint_on_failure():
+    run = _build_linear_run()
+    step = run.run_step("ingest", _fail("network error"))
+    assert step.status == StepStatus.FAILED
+    assert step.error == "network error"
+    assert len(step.checkpoints) == 1
+    assert step.checkpoints[0].status == StepStatus.FAILED
+
+
+def test_step_with_unmet_dependency_is_skipped():
+    run = _build_linear_run()
+    # transform depends on ingest, which has not run yet.
+    step = run.run_step("transform", _ok("should-not-run"))
+    assert step.status == StepStatus.SKIPPED
+    assert step.output is None
+
+
+def test_unknown_step_raises():
+    run = _build_linear_run()
+    with pytest.raises(StepNotFoundError):
+        run.run_step("does-not-exist", _ok("x"))
+
+
+# ---------------------------------------------------------------------------
+# Downstream invalidation
+# ---------------------------------------------------------------------------
+
+
+def test_downstream_of_returns_transitive_dependents():
+    run = _build_linear_run()
+    assert run.downstream_of("ingest") == ["transform", "publish"]
+    assert run.downstream_of("transform") == ["publish"]
+    assert run.downstream_of("publish") == []
+
+
+def test_failure_invalidates_downstream_succeeded_steps():
+    run = _build_linear_run()
+    run.run_step("ingest", _ok("data"))
+    run.run_step("transform", _ok("transformed"))
+    assert run.steps["transform"].status == StepStatus.SUCCEEDED
+
+    # Re-running ingest (e.g. with a fixed config) but it fails again.
+    run.run_step("ingest", _fail("still broken"))
+    assert run.steps["ingest"].status == StepStatus.FAILED
+    # transform had succeeded based on now-suspect upstream data -> invalidated
+    assert run.steps["transform"].status == StepStatus.INVALIDATED
+    # publish never ran, so it stays PENDING rather than being marked invalid.
+    assert run.steps["publish"].status == StepStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# Recovery action: retry same step / with edited inputs
+# ---------------------------------------------------------------------------
+
+
+def test_retry_same_step_after_failure():
+    run = _build_linear_run()
+    run.run_step("ingest", _fail("timeout"))
+    assert run.steps["ingest"].status == StepStatus.FAILED
+
+    step = run.retry_step("ingest", _ok("recovered"), reason="transient timeout")
+    assert step.status == StepStatus.SUCCEEDED
+    assert step.output == "recovered"
+
+    audit = run.audit_log[-1]
+    assert audit.action == RecoveryAction.RETRY_SAME
+    assert audit.step_id == "ingest"
+    assert audit.reason == "transient timeout"
+
+
+def test_retry_with_edited_inputs_updates_step_inputs_and_audit():
+    run = _build_linear_run()
+    run.run_step("ingest", _fail("bad endpoint"))
+
+    captured_inputs = {}
+
+    def executor(inputs):
+        captured_inputs.update(inputs)
+        return "ok"
+
+    run.retry_step(
+        "ingest",
+        executor,
+        edited_inputs={"source": "s3://bucket/fixed-file"},
+        actor="user-42",
+        reason="fixed the webhook endpoint config",
+    )
+
+    assert run.steps["ingest"].inputs["source"] == "s3://bucket/fixed-file"
+    assert captured_inputs["source"] == "s3://bucket/fixed-file"
+
+    audit = run.audit_log[-1]
+    assert audit.action == RecoveryAction.RETRY_WITH_EDITED_INPUT
+    assert audit.actor == "user-42"
+
+
+def test_cannot_retry_a_step_that_has_not_failed():
+    run = _build_linear_run()
+    run.run_step("ingest", _ok("data"))
+    with pytest.raises(InvalidRecoveryActionError):
+        run.retry_step("ingest", _ok("data-again"))
+
+
+# ---------------------------------------------------------------------------
+# Recovery action: resume from checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_resume_from_checkpoint_skips_completed_steps():
+    run = _build_linear_run()
+    run.run_step("ingest", _ok("data"))
+    run.run_step("transform", _ok("transformed"))
+    # publish fails first time.
+    run.run_step("publish", _fail("webhook down"))
+
+    call_counts = {"ingest": 0, "transform": 0, "publish": 0}
+
+    def make_tracker(step_id, value):
+        def _executor(_inputs):
+            call_counts[step_id] += 1
+            return value
+        return _executor
+
+    executed = run.resume_from_checkpoint({
+        "ingest": make_tracker("ingest", "data"),
+        "transform": make_tracker("transform", "transformed"),
+        "publish": make_tracker("publish", "published"),
+    })
+
+    # Only the failed step should have actually been re-executed.
+    assert call_counts == {"ingest": 0, "transform": 0, "publish": 1}
+    assert [s.step_id for s in executed] == ["publish"]
+    assert run.steps["publish"].status == StepStatus.SUCCEEDED
+    assert run.steps["ingest"].status == StepStatus.SUCCEEDED
+    assert run.steps["transform"].status == StepStatus.SUCCEEDED
+
+    audit = run.audit_log[-1]
+    assert audit.action == RecoveryAction.RESUME_FROM_CHECKPOINT
+    assert audit.affected_steps == ["publish"]
+
+
+def test_resume_from_checkpoint_reruns_invalidated_steps():
+    run = _build_linear_run()
+    run.run_step("ingest", _ok("v1"))
+    run.run_step("transform", _ok("transformed-v1"))
+    # ingest re-run fails -> invalidates transform.
+    run.run_step("ingest", _fail("broke"))
+    assert run.steps["transform"].status == StepStatus.INVALIDATED
+
+    executed = run.resume_from_checkpoint({
+        "ingest": _ok("v2"),
+        "transform": _ok("transformed-v2"),
+        "publish": _ok("published"),
+    })
+
+    executed_ids = {s.step_id for s in executed}
+    assert "ingest" in executed_ids
+    assert "transform" in executed_ids
+    assert run.steps["transform"].output == "transformed-v2"
+    assert run.steps["publish"].status == StepStatus.SUCCEEDED
+
+
+# ---------------------------------------------------------------------------
+# Recovery action: rerun downstream only
+# ---------------------------------------------------------------------------
+
+
+def test_rerun_downstream_leaves_upstream_intact():
+    run = _build_linear_run()
+    run.run_step("ingest", _ok("retrieved-doc"))
+    run.run_step("transform", _ok("draft-v1"))
+    run.run_step("publish", _ok("published-v1"))
+
+    ingest_calls = {"count": 0}
+
+    def ingest_executor(_inputs):
+        ingest_calls["count"] += 1
+        return "retrieved-doc"
+
+    executed = run.rerun_downstream(
+        "ingest",
+        {
+            "ingest": ingest_executor,  # should not be called — ingest is upstream of itself
+            "transform": _ok("draft-v2"),
+            "publish": _ok("published-v2"),
+        },
+        reason="checkpoint artifact edited",
+    )
+
+    # ingest itself is not downstream of itself, so it must not be touched.
+    assert ingest_calls["count"] == 0
+    assert run.steps["ingest"].output == "retrieved-doc"
+    assert run.steps["transform"].output == "draft-v2"
+    assert run.steps["publish"].output == "published-v2"
+    assert {s.step_id for s in executed} == {"transform", "publish"}
+
+    audit = run.audit_log[-1]
+    assert audit.action == RecoveryAction.RERUN_DOWNSTREAM
+    assert audit.step_id == "ingest"
+    assert set(audit.affected_steps) == {"transform", "publish"}
+
+
+# ---------------------------------------------------------------------------
+# Failure detail view payload (for the future frontend integration)
+# ---------------------------------------------------------------------------
+
+
+def test_failure_detail_includes_options_and_downstream_for_failed_step():
+    run = _build_linear_run()
+    run.run_step("ingest", _ok("data"))
+    run.run_step("transform", _ok("transformed"))
+    run.run_step("publish", _fail("webhook 500"))
+
+    detail = run.failure_detail("publish")
+    assert detail["status"] == StepStatus.FAILED.value
+    assert detail["error"] == "webhook 500"
+    assert set(detail["recovery_options"]) == {
+        RecoveryAction.RETRY_SAME.value,
+        RecoveryAction.RETRY_WITH_EDITED_INPUT.value,
+        RecoveryAction.RESUME_FROM_CHECKPOINT.value,
+        RecoveryAction.RERUN_DOWNSTREAM.value,
+    }
+    assert detail["affected_downstream_steps"] == []
+
+
+def test_failure_detail_has_no_recovery_options_for_healthy_step():
+    run = _build_linear_run()
+    run.run_step("ingest", _ok("data"))
+    detail = run.failure_detail("ingest")
+    assert detail["status"] == StepStatus.SUCCEEDED.value
+    assert detail["recovery_options"] == []
+
+
+def test_to_dict_serializes_run_state_and_audit_log():
+    run = _build_linear_run()
+    run.run_step("ingest", _fail("oops"))
+    run.retry_step("ingest", _ok("fixed"))
+
+    payload = run.to_dict()
+    assert payload["run_id"] == run.run_id
+    assert payload["steps"]["ingest"]["status"] == StepStatus.SUCCEEDED.value
+    assert payload["steps"]["ingest"]["checkpoint_count"] == 2
+    assert len(payload["audit_log"]) == 1
+    assert payload["audit_log"][0]["action"] == RecoveryAction.RETRY_SAME.value


### PR DESCRIPTION
Addresses #135

## What this implements

This is a scoped, working slice of the "Add failure recovery and resume-from-checkpoint for workflows and jobs" epic. It implements the **Recovery Model** building block the rest of the epic (frontend failure-detail view, backend recovery APIs wired into the live workflow engine) will build on top of.

Added `backend/services/workflow_recovery.py`: a storage-agnostic `WorkflowRun` engine that models a workflow as a DAG of `Step`s and provides:

- **Checkpointing**: every step execution (success or failure) appends a `StepCheckpoint` recording inputs, output/error, and attempt number.
- **Lineage-aware invalidation**: when a step fails, all *already-succeeded* downstream steps are marked `INVALIDATED` (steps that hadn't run yet are left `PENDING` rather than falsely flagged).
- **Recovery actions** (all auditable, see below):
  - `retry_step(..., edited_inputs=None)` — retry a failed/invalidated step, optionally with corrected inputs (`retry_same` vs `retry_with_edited_input`).
  - `resume_from_checkpoint(executors)` — resumes a whole run, skipping any step that already has a valid successful checkpoint, and only recomputing steps that are `PENDING`, `FAILED`, or `INVALIDATED`.
  - `rerun_downstream(step_id, executors)` — reruns only the steps transitively downstream of a given step (e.g. after an edited checkpoint artifact), leaving upstream steps untouched.
- **Auditable history**: every recovery action appends an immutable `AuditEntry` (action type, actor, reason, affected steps, timestamp) to `WorkflowRun.audit_log`.
- **Failure detail payload**: `WorkflowRun.failure_detail(step_id)` returns the shape a frontend failure-detail view would need (failing step, error, available recovery options, affected downstream steps) — ready to be wrapped in an API endpoint in a follow-up.

Added `backend/tests/test_workflow_recovery.py` with 15 tests covering: checkpointing on success/failure, unmet-dependency skip behavior, downstream invalidation, all four recovery actions, the "don't recompute completed steps" resume behavior, the "rerun only downstream" behavior, audit log contents, and the failure-detail payload shape. 96% line coverage on the new module (`ruff check` and `mypy --ignore-missing-imports` both pass clean).

While writing tests I found and fixed a real bug in an early draft: `resume_from_checkpoint` would incorrectly skip re-executing a step that was currently `FAILED` but had a stale successful checkpoint from an earlier attempt — fixed so `FAILED` steps are always re-executed on resume.

## Out of scope / follow-up

This PR intentionally does **not** attempt the full epic. Left for follow-up PRs:

- **Backend API endpoints** exposing these recovery actions over HTTP (e.g. `POST /api/workflows/<id>/steps/<step_id>/retry`, `/resume`, `/rerun-downstream`) and wiring into `app.py`'s blueprint/route registration.
- **Persistence**: `WorkflowRun` is currently in-memory only. A follow-up should back it with the ORM (`database/models.py`) or a JSON column so runs survive process restarts, and wire it into the existing `agents/multi_agent_system.py` `StateGraph`-based execution.
- **Frontend failure detail view** (failing step, error summary, recovery options, affected downstream tasks) and UI for triggering retry/resume/rerun actions — `frontend/` is untouched in this PR.
- **Scheduled/triggered runs and external tool-call retries** mentioned in the issue's "Why This Is Needed" section — not addressed here.
- **Approval-checkpoint semantics** (the "review checkpoint leads to an edited artifact" scenario) — the engine supports the underlying rerun-downstream mechanics, but there's no approval/review domain model yet.

## Test plan

- [x] `pytest backend/tests/test_workflow_recovery.py -v` — 15/15 passing
- [x] `ruff check backend/services/workflow_recovery.py backend/tests/test_workflow_recovery.py` — clean
- [x] `mypy backend/services/workflow_recovery.py --ignore-missing-imports` — clean
- [x] Coverage on new module: 96%
- [x] Confirmed pre-existing test collection errors in the sandbox (missing `flask` module) are unrelated to this change and present on `main` as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDp718wense5Kj6ZS2x68P)_