### PR TITLE
Add agent registry: structured metadata, lifecycle, and runtime compatibility validation

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -7,9 +7,33 @@ intelligent agent workflows using LangChain and MCP servers.
 
 from .reactive_agent import ReactiveDocumentAgent, WorkflowReactiveAgent
 from .config import AgentConfig
+from .registry import (
+    AgentCompatibilityError,
+    AgentDescriptor,
+    AgentLifecycleStatus,
+    AgentNotFoundError,
+    AgentRegistry,
+    CompatibilityIssue,
+    CompatibilityResult,
+    ResolvedAgentRun,
+    check_compatibility,
+    default_registry,
+    resolve_agent_for_run,
+)
 
 __all__ = [
     "ReactiveDocumentAgent",
-    "WorkflowReactiveAgent", 
-    "AgentConfig"
+    "WorkflowReactiveAgent",
+    "AgentConfig",
+    "AgentCompatibilityError",
+    "AgentDescriptor",
+    "AgentLifecycleStatus",
+    "AgentNotFoundError",
+    "AgentRegistry",
+    "CompatibilityIssue",
+    "CompatibilityResult",
+    "ResolvedAgentRun",
+    "check_compatibility",
+    "default_registry",
+    "resolve_agent_for_run",
 ]

--- a/backend/agents/multi_agent_system.py
+++ b/backend/agents/multi_agent_system.py
@@ -15,6 +15,13 @@ from api_endpoints.financeGPT.chatbot_endpoints import (
 )
 from .config import AgentConfig
 from .routing import route_boolean
+from .registry import (
+    AgentCompatibilityError,
+    AgentDescriptor,
+    AgentNotFoundError,
+    AgentRegistry,
+    resolve_agent_for_run,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +43,8 @@ class AgentState(TypedDict):
     next_agent: str
     completed_agents: List[str]
     stream_callback: Any
+    registry_agent_id: Optional[str]
+    registry_agent_version_used: Optional[str]
 
 
 class MultiAgentCallbackHandler(BaseCallbackHandler):
@@ -135,6 +144,114 @@ class BaseSpecializedAgent:
     def process(self, state: AgentState) -> Dict[str, Any]:
         """Override this method in specialized agents"""
         raise NotImplementedError("Each agent must implement the process method")
+
+
+class RegistryAgentNode(BaseSpecializedAgent):
+    """Workflow node that runs a registry agent, resolved by (agent_id, version).
+
+    This is the runtime-integration piece described in issue #136: a
+    workflow/crew can reference a registry agent by stable ID/version,
+    resolution + compatibility validation happens before the run executes,
+    and the exact resolved version is recorded for later inspection
+    (state['registry_agent_version_used']).
+    """
+
+    def __init__(
+        self,
+        registry: AgentRegistry,
+        agent_id: str,
+        version: Optional[str] = None,
+        model_type: int = 0,
+        model_key: Optional[str] = None,
+        available_tools: Optional[List[str]] = None,
+        available_providers: Optional[List[str]] = None,
+        granted_permissions: Optional[List[str]] = None,
+    ):
+        self.registry = registry
+        self.agent_id = agent_id
+        self.requested_version = version
+        self.available_tools = available_tools
+        self.available_providers = available_providers
+        self.granted_permissions = granted_permissions
+        # Resolution + compatibility validation happens at construction time
+        # so failures surface before the workflow starts running, per the
+        # issue's acceptance criterion.
+        resolved = resolve_agent_for_run(
+            registry,
+            agent_id,
+            version,
+            available_tools=available_tools,
+            available_providers=available_providers,
+            granted_permissions=granted_permissions,
+        )
+        self.descriptor: AgentDescriptor = resolved.descriptor
+        self.compatibility = resolved.compatibility
+        super().__init__(self.descriptor.name, model_type, model_key)
+
+    def process(self, state: AgentState) -> Dict[str, Any]:
+        """Run the resolved registry agent against the current task and
+        record which exact version executed."""
+        callback_handler = MultiAgentCallbackHandler(state["stream_callback"], self.name)
+
+        query = state["query"]
+        warnings = [issue.message for issue in self.compatibility.issues]
+
+        try:
+            prompt = (
+                f"You are the registry agent '{self.descriptor.name}' "
+                f"(id={self.descriptor.agent_id}, version={self.descriptor.version}).\n"
+                f"Description: {self.descriptor.description}\n\n"
+                f"Task: {query}\n\n"
+                "Respond with your best output for this task."
+            )
+            response = self.llm.invoke(
+                [
+                    SystemMessage(content=f"You are the specialized agent '{self.descriptor.name}'."),
+                    HumanMessage(content=prompt),
+                ],
+                config={"callbacks": [callback_handler]},
+            )
+            output = response.content
+
+            reasoning_step = {
+                "id": f"step-{int(time.time() * 1000)}",
+                "type": "registry_agent_completion",
+                "agent_name": self.name,
+                "agent_id": self.descriptor.agent_id,
+                "agent_version": self.descriptor.version,
+                "message": f"Registry agent '{self.descriptor.agent_id}'@{self.descriptor.version} completed",
+                "warnings": warnings,
+                "timestamp": int(time.time() * 1000),
+            }
+
+            return {
+                "final_answer": output,
+                "confidence_score": 0.8,
+                "reasoning_steps": state["reasoning_steps"] + [reasoning_step],
+                "completed_agents": state["completed_agents"] + [self.name],
+                "registry_agent_id": self.descriptor.agent_id,
+                "registry_agent_version_used": self.descriptor.version,
+                "next_agent": "OrchestratorAgent",
+            }
+        except Exception as e:
+            error_step = {
+                "id": f"step-{int(time.time() * 1000)}",
+                "type": "registry_agent_error",
+                "agent_name": self.name,
+                "agent_id": self.descriptor.agent_id,
+                "agent_version": self.descriptor.version,
+                "message": f"Registry agent '{self.descriptor.agent_id}' encountered an error",
+                "error": str(e),
+                "timestamp": int(time.time() * 1000),
+            }
+            return {
+                "confidence_score": 0.1,
+                "reasoning_steps": state["reasoning_steps"] + [error_step],
+                "completed_agents": state["completed_agents"] + [self.name],
+                "registry_agent_id": self.descriptor.agent_id,
+                "registry_agent_version_used": self.descriptor.version,
+                "next_agent": "OrchestratorAgent",
+            }
 
 
 class DocumentRetrievalAgent(BaseSpecializedAgent):
@@ -707,34 +824,76 @@ class OrchestratorAgent(BaseSpecializedAgent):
 class MultiAgentDocumentSystem:
     """Main multi-agent system using LangGraph"""
     
-    def __init__(self, model_type: int = 0, model_key: Optional[str] = None):
+    def __init__(
+        self,
+        model_type: int = 0,
+        model_key: Optional[str] = None,
+        registry: Optional[AgentRegistry] = None,
+        registry_agent_id: Optional[str] = None,
+        registry_agent_version: Optional[str] = None,
+        registry_available_tools: Optional[List[str]] = None,
+        registry_available_providers: Optional[List[str]] = None,
+        registry_granted_permissions: Optional[List[str]] = None,
+    ):
         self.model_type = model_type
         self.model_key = model_key
-        
+
         #initialize agents
         self.agents = {"DocumentListAgent": DocumentListAgent(model_type, model_key), "ChatHistoryAgent": ChatHistoryAgent(model_type, model_key),
             "DocumentRetrievalAgent": DocumentRetrievalAgent(model_type, model_key),
             "GeneralKnowledgeAgent": GeneralKnowledgeAgent(model_type, model_key),
             "OrchestratorAgent": OrchestratorAgent(model_type, model_key)
         }
-        
+
+        # Optional registry agent participation: when an agent_id is supplied,
+        # resolve + validate it against the registry up front (raises
+        # AgentNotFoundError / AgentCompatibilityError before the workflow
+        # ever runs) and splice it into the graph as an entry node ahead of
+        # DocumentListAgent. This is the "workflow references a registry
+        # agent and executes it at runtime" path from issue #136.
+        self.registry_agent_node: Optional[RegistryAgentNode] = None
+        if registry is not None and registry_agent_id is not None:
+            self.registry_agent_node = RegistryAgentNode(
+                registry,
+                registry_agent_id,
+                registry_agent_version,
+                model_type,
+                model_key,
+                available_tools=registry_available_tools,
+                available_providers=registry_available_providers,
+                granted_permissions=registry_granted_permissions,
+            )
+            self.agents["RegistryAgent"] = self.registry_agent_node
+
         # Build the workflow graph
         self.workflow = self._build_workflow()
-    
+
     def _build_workflow(self) -> StateGraph:
         """Build the LangGraph workflow"""
         workflow = StateGraph(AgentState)
-        
+
         # Add agent nodes
         workflow.add_node("DocumentListAgent", self._run_document_list_agent)
         workflow.add_node("ChatHistoryAgent", self._run_chat_history_agent)
         workflow.add_node("DocumentRetrievalAgent", self._run_document_retrieval_agent)
         workflow.add_node("GeneralKnowledgeAgent", self._run_general_knowledge_agent)
         workflow.add_node("OrchestratorAgent", self._run_orchestrator_agent)
-        
-        # Define workflow edges - start with document list to check for document-specific queries
-        workflow.set_entry_point("DocumentListAgent")
-        
+
+        if self.registry_agent_node is not None:
+            workflow.add_node("RegistryAgent", self._run_registry_agent)
+            workflow.set_entry_point("RegistryAgent")
+            workflow.add_conditional_edges(
+                "RegistryAgent",
+                self._route_next_agent,
+                {
+                    "OrchestratorAgent": "OrchestratorAgent",
+                    "END": END,
+                },
+            )
+        else:
+            # Define workflow edges - start with document list to check for document-specific queries
+            workflow.set_entry_point("DocumentListAgent")
+
         # Add conditional edges based on next_agent field
         workflow.add_conditional_edges(
             "DocumentListAgent",
@@ -811,6 +970,10 @@ class MultiAgentDocumentSystem:
     def _run_orchestrator_agent(self, state: AgentState) -> AgentState:
         result = self.agents["OrchestratorAgent"].process(state)
         return {**state, **result}
+
+    def _run_registry_agent(self, state: AgentState) -> AgentState:
+        result = self.agents["RegistryAgent"].process(state)
+        return {**state, **result}
     
     def process_query_stream(self, query: str, chat_id: int, user_email: str) -> Generator[Dict[str, Any], None, None]:
         """
@@ -845,9 +1008,11 @@ class MultiAgentDocumentSystem:
                 final_answer="",
                 confidence_score=0.5,
                 reasoning_steps=[],
-                next_agent="DocumentListAgent",
+                next_agent="RegistryAgent" if self.registry_agent_node is not None else "DocumentListAgent",
                 completed_agents=[],
-                stream_callback=stream_callback
+                stream_callback=stream_callback,
+                registry_agent_id=None,
+                registry_agent_version_used=None,
             )
             
             # Process through the workflow
@@ -887,7 +1052,9 @@ class MultiAgentDocumentSystem:
                 document_sources = final_state.get("document_sources", [])
                 confidence_score = final_state.get("confidence_score", 0.5)
                 reasoning_steps = final_state.get("reasoning_steps", [])
-                
+                registry_agent_id = final_state.get("registry_agent_id")
+                registry_agent_version_used = final_state.get("registry_agent_version_used")
+
                 # Yield completion event
                 yield {
                     "type": "complete",
@@ -895,6 +1062,8 @@ class MultiAgentDocumentSystem:
                     "sources": document_sources,
                     "confidence": confidence_score,
                     "total_agents_used": len(final_state.get("completed_agents", [])),
+                    "registry_agent_id": registry_agent_id,
+                    "registry_agent_version_used": registry_agent_version_used,
                     "timestamp": self._get_timestamp()
                 }
                 

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -1,0 +1,389 @@
+"""
+Agent Registry — runtime integration for registry-backed agents.
+
+This module gives registry agents structured, machine-checkable metadata and a
+resolution/compatibility-validation layer so that workflows and crews can
+reference an agent by a stable ``(agent_id, version)`` pair and have the
+runtime verify — before a run starts — that the agent can actually execute in
+the current environment (required tools present, model/provider available,
+permissions satisfied).
+
+This is the foundation piece of the larger "registry agents in live
+workflows" effort (see GitHub issue #136). It intentionally does not attempt
+the entire epic (install/update/disable/deprecate lifecycle HTTP endpoints,
+the frontend builder UI, etc.) — see the PR description for what is
+explicitly out of scope.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+class AgentLifecycleStatus:
+    """Lifecycle states a registry agent version can be in."""
+
+    ACTIVE = "active"
+    DEPRECATED = "deprecated"
+    DISABLED = "disabled"
+
+    ALL = (ACTIVE, DEPRECATED, DISABLED)
+
+
+def _parse_version(version: str) -> Tuple[int, int, int]:
+    if not _VERSION_RE.match(version or ""):
+        raise ValueError(
+            f"Invalid agent version '{version}'. Expected semantic version 'MAJOR.MINOR.PATCH'."
+        )
+    major, minor, patch = (int(part) for part in version.split("."))
+    return major, minor, patch
+
+
+@dataclass(frozen=True)
+class AgentDescriptor:
+    """Structured metadata describing one version of a registry agent.
+
+    This is the descriptor referenced in the issue's "Agent Metadata" scope:
+    name, description, version, supported task categories, tool
+    requirements, model/provider requirements, input/output expectations,
+    and permission requirements.
+    """
+
+    agent_id: str
+    name: str
+    description: str
+    version: str
+    task_categories: Tuple[str, ...] = field(default_factory=tuple)
+    required_tools: Tuple[str, ...] = field(default_factory=tuple)
+    supported_providers: Tuple[str, ...] = field(default_factory=tuple)
+    required_permissions: Tuple[str, ...] = field(default_factory=tuple)
+    input_schema: Dict[str, Any] = field(default_factory=dict)
+    output_schema: Dict[str, Any] = field(default_factory=dict)
+    status: str = AgentLifecycleStatus.ACTIVE
+
+    def __post_init__(self) -> None:
+        if not self.agent_id:
+            raise ValueError("agent_id is required")
+        if not self.name:
+            raise ValueError("name is required")
+        _parse_version(self.version)  # raises ValueError if malformed
+        if self.status not in AgentLifecycleStatus.ALL:
+            raise ValueError(
+                f"Invalid status '{self.status}'. Must be one of {AgentLifecycleStatus.ALL}."
+            )
+
+    @property
+    def version_tuple(self) -> Tuple[int, int, int]:
+        return _parse_version(self.version)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+            "task_categories": list(self.task_categories),
+            "required_tools": list(self.required_tools),
+            "supported_providers": list(self.supported_providers),
+            "required_permissions": list(self.required_permissions),
+            "input_schema": self.input_schema,
+            "output_schema": self.output_schema,
+            "status": self.status,
+        }
+
+
+@dataclass(frozen=True)
+class CompatibilityIssue:
+    """A single actionable compatibility failure."""
+
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class CompatibilityResult:
+    """Outcome of validating an agent descriptor against a runtime environment."""
+
+    ok: bool
+    issues: Tuple[CompatibilityIssue, ...] = field(default_factory=tuple)
+
+    def raise_if_incompatible(self) -> None:
+        if not self.ok:
+            details = "; ".join(f"[{issue.code}] {issue.message}" for issue in self.issues)
+            raise AgentCompatibilityError(details, self.issues)
+
+
+class AgentCompatibilityError(RuntimeError):
+    """Raised when a resolved agent fails a pre-run compatibility check."""
+
+    def __init__(self, message: str, issues: Tuple[CompatibilityIssue, ...] = ()):
+        super().__init__(message)
+        self.issues = issues
+
+
+class AgentNotFoundError(LookupError):
+    """Raised when a workflow references an agent_id/version that does not exist."""
+
+
+class AgentRegistry:
+    """In-memory registry of versioned agent descriptors.
+
+    Supports the lifecycle operations called out in the issue: install,
+    update (publish a new version), disable, and deprecate. Multiple
+    versions of the same agent_id may coexist so that runs pinned to an
+    older version keep working after a workspace updates to a newer one.
+    """
+
+    def __init__(self) -> None:
+        # agent_id -> version -> descriptor
+        self._agents: Dict[str, Dict[str, AgentDescriptor]] = {}
+
+    # -- lifecycle -----------------------------------------------------
+    def install(self, descriptor: AgentDescriptor) -> None:
+        """Install (register) a new agent version. Idempotent re-install of
+        the same agent_id/version with identical metadata is allowed; a
+        conflicting redefinition is rejected."""
+        versions = self._agents.setdefault(descriptor.agent_id, {})
+        existing = versions.get(descriptor.version)
+        if existing is not None and existing != descriptor:
+            raise ValueError(
+                f"Agent '{descriptor.agent_id}' version '{descriptor.version}' is already "
+                "installed with different metadata. Publish a new version instead."
+            )
+        versions[descriptor.version] = descriptor
+        logger.info("Installed agent %s@%s", descriptor.agent_id, descriptor.version)
+
+    def update(self, descriptor: AgentDescriptor) -> None:
+        """Publish a new version of an existing agent. Older versions remain
+        installed and resolvable so pinned runs are unaffected."""
+        if descriptor.agent_id not in self._agents:
+            raise AgentNotFoundError(
+                f"Cannot update unknown agent '{descriptor.agent_id}'. Install it first."
+            )
+        self.install(descriptor)
+
+    def disable(self, agent_id: str, version: str) -> None:
+        """Mark a specific version as disabled. Disabled versions fail
+        compatibility checks at resolution time but are not deleted."""
+        descriptor = self._require(agent_id, version)
+        self._agents[agent_id][version] = AgentDescriptor(
+            **{**descriptor.to_dict(), "status": AgentLifecycleStatus.DISABLED}
+        )
+
+    def deprecate(self, agent_id: str, version: str) -> None:
+        """Mark a specific version as deprecated. Deprecated versions still
+        resolve and run (so existing pinned workflows are not broken) but
+        compatibility checks will return a warning-level issue callers can
+        surface to users."""
+        descriptor = self._require(agent_id, version)
+        self._agents[agent_id][version] = AgentDescriptor(
+            **{**descriptor.to_dict(), "status": AgentLifecycleStatus.DEPRECATED}
+        )
+
+    # -- lookup ----------------------------------------------------------
+    def _require(self, agent_id: str, version: str) -> AgentDescriptor:
+        versions = self._agents.get(agent_id)
+        if not versions or version not in versions:
+            raise AgentNotFoundError(f"Agent '{agent_id}' version '{version}' not found in registry.")
+        return versions[version]
+
+    def get(self, agent_id: str, version: Optional[str] = None) -> AgentDescriptor:
+        """Resolve an agent by id and (optional) version. When version is
+        omitted, resolves to the highest installed version that is not
+        disabled (preferring active over deprecated)."""
+        versions = self._agents.get(agent_id)
+        if not versions:
+            raise AgentNotFoundError(f"Agent '{agent_id}' is not in the registry.")
+        if version is not None:
+            return self._require(agent_id, version)
+
+        candidates = [d for d in versions.values() if d.status != AgentLifecycleStatus.DISABLED]
+        if not candidates:
+            raise AgentNotFoundError(
+                f"Agent '{agent_id}' has no enabled versions installed."
+            )
+        candidates.sort(
+            key=lambda d: (d.status == AgentLifecycleStatus.ACTIVE, d.version_tuple),
+            reverse=True,
+        )
+        return candidates[0]
+
+    def list_versions(self, agent_id: str) -> List[AgentDescriptor]:
+        versions = self._agents.get(agent_id, {})
+        return sorted(versions.values(), key=lambda d: d.version_tuple)
+
+    def list_agents(self) -> List[str]:
+        return sorted(self._agents.keys())
+
+    def find_by_task_category(self, task_category: str) -> List[AgentDescriptor]:
+        """Orchestration-time routing helper: return the best (highest
+        version, enabled) descriptor per agent_id that supports the given
+        task category."""
+        matches = []
+        for agent_id in self._agents:
+            try:
+                descriptor = self.get(agent_id)
+            except AgentNotFoundError:
+                continue
+            if task_category in descriptor.task_categories:
+                matches.append(descriptor)
+        return matches
+
+
+# -- compatibility validation --------------------------------------------
+
+def check_compatibility(
+    descriptor: AgentDescriptor,
+    *,
+    available_tools: Optional[List[str]] = None,
+    available_providers: Optional[List[str]] = None,
+    granted_permissions: Optional[List[str]] = None,
+) -> CompatibilityResult:
+    """Validate that ``descriptor`` can run given the current runtime
+    environment. Mirrors the issue's acceptance criterion: "Compatibility
+    failures are caught before or at run startup with actionable errors."
+
+    Environment values default to reading from the process (env vars / a
+    static capability list) when not explicitly supplied, so callers can
+    either pass exact values (e.g. in tests) or rely on defaults in
+    production call sites.
+    """
+    issues: List[CompatibilityIssue] = []
+
+    if descriptor.status == AgentLifecycleStatus.DISABLED:
+        issues.append(
+            CompatibilityIssue(
+                code="agent_disabled",
+                message=(
+                    f"Agent '{descriptor.agent_id}'@{descriptor.version} has been disabled "
+                    "and cannot be used in new runs."
+                ),
+            )
+        )
+
+    if descriptor.status == AgentLifecycleStatus.DEPRECATED:
+        issues.append(
+            CompatibilityIssue(
+                code="agent_deprecated",
+                message=(
+                    f"Agent '{descriptor.agent_id}'@{descriptor.version} is deprecated. "
+                    "Consider migrating to a newer version."
+                ),
+            )
+        )
+
+    tools = set(available_tools if available_tools is not None else _default_available_tools())
+    missing_tools = [tool for tool in descriptor.required_tools if tool not in tools]
+    if missing_tools:
+        issues.append(
+            CompatibilityIssue(
+                code="missing_tools",
+                message=(
+                    f"Agent '{descriptor.agent_id}' requires tool(s) {missing_tools} "
+                    "which are not registered in this environment."
+                ),
+            )
+        )
+
+    providers = set(
+        available_providers if available_providers is not None else _default_available_providers()
+    )
+    if descriptor.supported_providers and not (set(descriptor.supported_providers) & providers):
+        issues.append(
+            CompatibilityIssue(
+                code="no_supported_provider",
+                message=(
+                    f"Agent '{descriptor.agent_id}' supports provider(s) "
+                    f"{list(descriptor.supported_providers)}, but none are configured "
+                    f"(available: {sorted(providers)})."
+                ),
+            )
+        )
+
+    permissions = set(granted_permissions if granted_permissions is not None else [])
+    missing_permissions = [
+        perm for perm in descriptor.required_permissions if perm not in permissions
+    ]
+    if missing_permissions:
+        issues.append(
+            CompatibilityIssue(
+                code="missing_permissions",
+                message=(
+                    f"Agent '{descriptor.agent_id}' requires permission(s) "
+                    f"{missing_permissions} that have not been granted to this run."
+                ),
+            )
+        )
+
+    # "disabled"/"deprecated" issues are advisory for deprecated but blocking for disabled.
+    blocking = [i for i in issues if i.code != "agent_deprecated"]
+    return CompatibilityResult(ok=not blocking, issues=tuple(issues))
+
+
+def _default_available_tools() -> List[str]:
+    return []
+
+
+def _default_available_providers() -> List[str]:
+    providers = []
+    if os.getenv("OPENAI_API_KEY"):
+        providers.append("openai")
+    if os.getenv("ANTHROPIC_API_KEY"):
+        providers.append("anthropic")
+    return providers
+
+
+# -- workflow-facing resolution -------------------------------------------
+
+@dataclass(frozen=True)
+class ResolvedAgentRun:
+    """Result of resolving + validating a registry agent reference for a run.
+
+    ``descriptor`` carries the exact agent version that participated, which
+    callers should persist alongside the run record (acceptance criterion:
+    "Runs record the specific agent version used.").
+    """
+
+    descriptor: AgentDescriptor
+    compatibility: CompatibilityResult
+
+
+def resolve_agent_for_run(
+    registry: AgentRegistry,
+    agent_id: str,
+    version: Optional[str] = None,
+    *,
+    available_tools: Optional[List[str]] = None,
+    available_providers: Optional[List[str]] = None,
+    granted_permissions: Optional[List[str]] = None,
+) -> ResolvedAgentRun:
+    """Resolve a registry agent reference (id + optional pinned version) and
+    run its pre-flight compatibility check. Raises ``AgentNotFoundError`` if
+    the agent/version is unknown, or ``AgentCompatibilityError`` if it fails
+    a blocking compatibility check. On success, returns the resolved
+    descriptor (including the exact version) for the caller to record on
+    the run.
+    """
+    descriptor = registry.get(agent_id, version)
+    compatibility = check_compatibility(
+        descriptor,
+        available_tools=available_tools,
+        available_providers=available_providers,
+        granted_permissions=granted_permissions,
+    )
+    compatibility.raise_if_incompatible()
+    return ResolvedAgentRun(descriptor=descriptor, compatibility=compatibility)
+
+
+# A module-level default registry instance that the rest of the backend
+# (multi_agent_system, future API endpoints) can import and populate.
+default_registry = AgentRegistry()

--- a/backend/tests/test_agent_registry.py
+++ b/backend/tests/test_agent_registry.py
@@ -1,0 +1,372 @@
+"""Tests for agents/registry.py — registry agent metadata, lookup, lifecycle,
+and pre-run compatibility validation (issue #136: runtime integration of
+registry agents into live workflows)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_registry() -> Any:
+    """Load agents/registry.py directly by file path.
+
+    registry.py imports only the standard library, so loading it standalone
+    avoids the heavy `agents` package __init__ (langchain/langgraph) and lets
+    these tests run with no extra deps, no network, and no API key.
+
+    The module is registered in sys.modules under its real name before
+    exec'ing, because dataclasses' field-type resolution looks the defining
+    module up via sys.modules[cls.__module__].
+    """
+    path = Path(__file__).resolve().parents[1] / "agents" / "registry.py"
+    spec = importlib.util.spec_from_file_location("_agents_registry", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_agents_registry"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+registry_mod = _load_registry()
+
+
+def _make_descriptor(**overrides: Any):
+    defaults = dict(
+        agent_id="lead-research-agent",
+        name="Lead Research Agent",
+        description="Sources and qualifies prospects for outreach workflows.",
+        version="1.0.0",
+        task_categories=("outreach", "lead-research"),
+        required_tools=("web_search",),
+        supported_providers=("openai", "anthropic"),
+        required_permissions=("network.read",),
+    )
+    defaults.update(overrides)
+    return registry_mod.AgentDescriptor(**defaults)
+
+
+# -- AgentDescriptor validation -------------------------------------------- #
+
+
+def test_descriptor_round_trips_to_dict() -> None:
+    descriptor = _make_descriptor()
+    as_dict = descriptor.to_dict()
+    assert as_dict["agent_id"] == "lead-research-agent"
+    assert as_dict["task_categories"] == ["outreach", "lead-research"]
+    assert as_dict["status"] == registry_mod.AgentLifecycleStatus.ACTIVE
+
+
+def test_descriptor_rejects_malformed_version() -> None:
+    with pytest.raises(ValueError):
+        _make_descriptor(version="not-a-version")
+
+
+def test_descriptor_rejects_missing_agent_id() -> None:
+    with pytest.raises(ValueError):
+        _make_descriptor(agent_id="")
+
+
+def test_descriptor_rejects_invalid_status() -> None:
+    with pytest.raises(ValueError):
+        _make_descriptor(status="archived")
+
+
+def test_descriptor_version_tuple() -> None:
+    descriptor = _make_descriptor(version="2.3.4")
+    assert descriptor.version_tuple == (2, 3, 4)
+
+
+# -- AgentRegistry: install / update / disable / deprecate ----------------- #
+
+
+def test_install_and_get_agent() -> None:
+    reg = registry_mod.AgentRegistry()
+    descriptor = _make_descriptor()
+    reg.install(descriptor)
+    assert reg.get("lead-research-agent") == descriptor
+
+
+def test_install_conflicting_redefinition_raises() -> None:
+    reg = registry_mod.AgentRegistry()
+    reg.install(_make_descriptor())
+    with pytest.raises(ValueError):
+        reg.install(_make_descriptor(description="A different description"))
+
+
+def test_install_idempotent_for_identical_descriptor() -> None:
+    reg = registry_mod.AgentRegistry()
+    descriptor = _make_descriptor()
+    reg.install(descriptor)
+    reg.install(descriptor)  # no error
+    assert reg.list_versions("lead-research-agent") == [descriptor]
+
+
+def test_update_requires_existing_agent() -> None:
+    reg = registry_mod.AgentRegistry()
+    with pytest.raises(registry_mod.AgentNotFoundError):
+        reg.update(_make_descriptor())
+
+
+def test_update_publishes_new_version_and_keeps_old() -> None:
+    reg = registry_mod.AgentRegistry()
+    v1 = _make_descriptor(version="1.0.0")
+    reg.install(v1)
+    v2 = _make_descriptor(version="2.0.0", description="Improved sourcing logic.")
+    reg.update(v2)
+
+    assert reg.get("lead-research-agent") == v2  # latest resolves by default
+    assert reg.get("lead-research-agent", version="1.0.0") == v1  # pinned still works
+    assert len(reg.list_versions("lead-research-agent")) == 2
+
+
+def test_get_unknown_agent_raises() -> None:
+    reg = registry_mod.AgentRegistry()
+    with pytest.raises(registry_mod.AgentNotFoundError):
+        reg.get("does-not-exist")
+
+
+def test_get_unknown_version_raises() -> None:
+    reg = registry_mod.AgentRegistry()
+    reg.install(_make_descriptor(version="1.0.0"))
+    with pytest.raises(registry_mod.AgentNotFoundError):
+        reg.get("lead-research-agent", version="9.9.9")
+
+
+def test_disable_excludes_from_default_resolution() -> None:
+    reg = registry_mod.AgentRegistry()
+    reg.install(_make_descriptor(version="1.0.0"))
+    reg.disable("lead-research-agent", "1.0.0")
+
+    with pytest.raises(registry_mod.AgentNotFoundError):
+        reg.get("lead-research-agent")  # no enabled versions left
+
+    # Pinned lookup still finds it (so callers can introspect status / error nicely).
+    pinned = reg.get("lead-research-agent", version="1.0.0")
+    assert pinned.status == registry_mod.AgentLifecycleStatus.DISABLED
+
+
+def test_deprecate_keeps_resolvable() -> None:
+    reg = registry_mod.AgentRegistry()
+    reg.install(_make_descriptor(version="1.0.0"))
+    reg.deprecate("lead-research-agent", "1.0.0")
+
+    resolved = reg.get("lead-research-agent")
+    assert resolved.status == registry_mod.AgentLifecycleStatus.DEPRECATED
+
+
+def test_default_resolution_prefers_active_over_deprecated_even_if_older() -> None:
+    reg = registry_mod.AgentRegistry()
+    v1 = _make_descriptor(version="1.0.0")
+    v2 = _make_descriptor(version="2.0.0")
+    reg.install(v1)
+    reg.install(v2)
+    reg.deprecate("lead-research-agent", "2.0.0")
+
+    # v2 is newer but deprecated; v1 is active -> v1 should win.
+    resolved = reg.get("lead-research-agent")
+    assert resolved.version == "1.0.0"
+
+
+def test_find_by_task_category() -> None:
+    reg = registry_mod.AgentRegistry()
+    reg.install(_make_descriptor(agent_id="lead-research-agent", task_categories=("outreach",)))
+    reg.install(
+        _make_descriptor(
+            agent_id="code-review-agent",
+            name="Code Review Agent",
+            task_categories=("coding", "code-review"),
+        )
+    )
+
+    matches = reg.find_by_task_category("outreach")
+    assert [d.agent_id for d in matches] == ["lead-research-agent"]
+
+    matches = reg.find_by_task_category("code-review")
+    assert [d.agent_id for d in matches] == ["code-review-agent"]
+
+    assert reg.find_by_task_category("nonexistent-category") == []
+
+
+def test_list_agents() -> None:
+    reg = registry_mod.AgentRegistry()
+    reg.install(_make_descriptor(agent_id="b-agent"))
+    reg.install(_make_descriptor(agent_id="a-agent"))
+    assert reg.list_agents() == ["a-agent", "b-agent"]
+
+
+# -- compatibility validation ------------------------------------------------ #
+
+
+def test_compatibility_ok_when_all_requirements_met() -> None:
+    descriptor = _make_descriptor()
+    result = registry_mod.check_compatibility(
+        descriptor,
+        available_tools=["web_search"],
+        available_providers=["openai"],
+        granted_permissions=["network.read"],
+    )
+    assert result.ok
+    assert result.issues == ()
+
+
+def test_compatibility_reports_missing_tools() -> None:
+    descriptor = _make_descriptor()
+    result = registry_mod.check_compatibility(
+        descriptor,
+        available_tools=[],
+        available_providers=["openai"],
+        granted_permissions=["network.read"],
+    )
+    assert not result.ok
+    assert any(issue.code == "missing_tools" for issue in result.issues)
+    assert "web_search" in result.issues[0].message
+
+
+def test_compatibility_reports_unsupported_provider() -> None:
+    descriptor = _make_descriptor(supported_providers=("anthropic",))
+    result = registry_mod.check_compatibility(
+        descriptor,
+        available_tools=["web_search"],
+        available_providers=["openai"],
+        granted_permissions=["network.read"],
+    )
+    assert not result.ok
+    assert any(issue.code == "no_supported_provider" for issue in result.issues)
+
+
+def test_compatibility_reports_missing_permissions() -> None:
+    descriptor = _make_descriptor()
+    result = registry_mod.check_compatibility(
+        descriptor,
+        available_tools=["web_search"],
+        available_providers=["openai"],
+        granted_permissions=[],
+    )
+    assert not result.ok
+    assert any(issue.code == "missing_permissions" for issue in result.issues)
+
+
+def test_compatibility_disabled_agent_is_blocking() -> None:
+    descriptor = _make_descriptor(status=registry_mod.AgentLifecycleStatus.DISABLED)
+    result = registry_mod.check_compatibility(
+        descriptor,
+        available_tools=["web_search"],
+        available_providers=["openai"],
+        granted_permissions=["network.read"],
+    )
+    assert not result.ok
+    assert any(issue.code == "agent_disabled" for issue in result.issues)
+
+
+def test_compatibility_deprecated_agent_is_advisory_not_blocking() -> None:
+    descriptor = _make_descriptor(status=registry_mod.AgentLifecycleStatus.DEPRECATED)
+    result = registry_mod.check_compatibility(
+        descriptor,
+        available_tools=["web_search"],
+        available_providers=["openai"],
+        granted_permissions=["network.read"],
+    )
+    assert result.ok  # deprecated alone shouldn't block a run
+    assert any(issue.code == "agent_deprecated" for issue in result.issues)
+
+
+def test_compatibility_result_raise_if_incompatible() -> None:
+    descriptor = _make_descriptor()
+    result = registry_mod.check_compatibility(
+        descriptor, available_tools=[], available_providers=[], granted_permissions=[]
+    )
+    with pytest.raises(registry_mod.AgentCompatibilityError):
+        result.raise_if_incompatible()
+
+
+def test_compatibility_result_ok_does_not_raise() -> None:
+    descriptor = _make_descriptor()
+    result = registry_mod.check_compatibility(
+        descriptor,
+        available_tools=["web_search"],
+        available_providers=["openai"],
+        granted_permissions=["network.read"],
+    )
+    result.raise_if_incompatible()  # should not raise
+
+
+def test_default_available_providers_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert registry_mod._default_available_providers() == ["openai"]
+
+
+# -- resolve_agent_for_run (the workflow-facing entry point) ---------------- #
+
+
+def test_resolve_agent_for_run_success_records_resolved_version() -> None:
+    reg = registry_mod.AgentRegistry()
+    reg.install(_make_descriptor(version="1.0.0"))
+    reg.install(_make_descriptor(version="2.0.0"))
+
+    resolved = registry_mod.resolve_agent_for_run(
+        reg,
+        "lead-research-agent",
+        version="1.0.0",
+        available_tools=["web_search"],
+        available_providers=["openai"],
+        granted_permissions=["network.read"],
+    )
+    assert resolved.descriptor.version == "1.0.0"
+    assert resolved.compatibility.ok
+
+
+def test_resolve_agent_for_run_unknown_agent_raises_not_found() -> None:
+    reg = registry_mod.AgentRegistry()
+    with pytest.raises(registry_mod.AgentNotFoundError):
+        registry_mod.resolve_agent_for_run(reg, "ghost-agent")
+
+
+def test_resolve_agent_for_run_incompatible_raises_with_actionable_message() -> None:
+    reg = registry_mod.AgentRegistry()
+    reg.install(_make_descriptor())
+
+    with pytest.raises(registry_mod.AgentCompatibilityError) as excinfo:
+        registry_mod.resolve_agent_for_run(
+            reg,
+            "lead-research-agent",
+            available_tools=[],
+            available_providers=[],
+            granted_permissions=[],
+        )
+    message = str(excinfo.value)
+    assert "missing_tools" in message
+    assert "web_search" in message
+
+
+def test_resolve_agent_for_run_pins_older_version_after_workspace_update() -> None:
+    """Mirrors the issue's example scenario: a workspace updates to a newer
+    agent version, but a run pinned to the prior stable version keeps working."""
+    reg = registry_mod.AgentRegistry()
+    v1 = _make_descriptor(version="1.0.0")
+    reg.install(v1)
+    reg.update(_make_descriptor(version="2.0.0"))
+
+    pinned_run = registry_mod.resolve_agent_for_run(
+        reg,
+        "lead-research-agent",
+        version="1.0.0",
+        available_tools=["web_search"],
+        available_providers=["openai"],
+        granted_permissions=["network.read"],
+    )
+    assert pinned_run.descriptor.version == "1.0.0"
+
+    latest_run = registry_mod.resolve_agent_for_run(
+        reg,
+        "lead-research-agent",
+        available_tools=["web_search"],
+        available_providers=["openai"],
+        granted_permissions=["network.read"],
+    )
+    assert latest_run.descriptor.version == "2.0.0"


### PR DESCRIPTION
Addresses #136

## What this implements

Issue #136 is a large product epic ("Integrate registry agents into live workflow and crew execution"). This PR implements a scoped, tractable subset: the **foundational agent registry module** with structured metadata and runtime compatibility validation, plus a real integration point that lets a workflow execute a registry agent at run time.

Specifically, in `backend/agents/`:

- **`registry.py`** (new): a versioned `AgentRegistry` with:
  - `AgentDescriptor` — structured metadata per the issue's "Agent Metadata" scope: name, description, semantic version, supported task categories, required tools, supported model/providers, required permissions, and input/output schema placeholders. Validates itself on construction (well-formed semver, valid status, required fields).
  - Lifecycle operations: `install`, `update` (publish a new version while keeping old ones resolvable), `disable`, `deprecate`.
  - Lookup: `get(agent_id, version=None)` resolves to the latest enabled version when unpinned, or an exact pinned version — so a workspace can update to a newer agent version while runs already pinned to an older version keep working (per the issue's example scenario).
  - `find_by_task_category(...)` — orchestration-time routing helper.
  - `check_compatibility(...)` — validates required tools / supported providers / granted permissions against the runtime environment and returns actionable `CompatibilityIssue`s. A disabled agent is a blocking failure; a deprecated agent is advisory (the issue's acceptance criterion: "Compatibility failures are caught before or at run startup with actionable errors").
  - `resolve_agent_for_run(...)` — the workflow-facing entry point: resolves + validates in one call, raising `AgentNotFoundError` or `AgentCompatibilityError` with details before a run starts.

- **`multi_agent_system.py`** (modified): added `RegistryAgentNode`, a workflow node that wraps a resolved `AgentDescriptor` and actually executes it (LLM call against the descriptor's name/description) as a participant in the existing LangGraph workflow. `MultiAgentDocumentSystem` now accepts optional `registry`/`registry_agent_id`/`registry_agent_version` constructor args: when supplied, resolution + compatibility validation happens at construction time (before the graph runs), the registry agent is spliced in as the entry node, and the exact resolved version is recorded on `AgentState` (`registry_agent_id`, `registry_agent_version_used`) and surfaced in the `complete` stream event — satisfying the acceptance criterion "Runs record the specific agent version used."

- **`agents/__init__.py`** (modified): exports the new registry types.

- **`tests/test_agent_registry.py`** (new): 30 tests covering descriptor validation, install/update/disable/deprecate lifecycle, version-pinned vs. latest resolution, task-category lookup, compatibility validation (missing tools/providers/permissions, disabled vs. deprecated), and `resolve_agent_for_run` end-to-end including the "pin to older version after workspace update" scenario. All pass; verified pre-existing/unrelated test-collection failures (missing `flask`/`cffi` native deps in this sandbox) are unaffected by this change (reproduced the same failures on `main` via `git stash`).

## Out of scope / left for follow-up

This is a partial implementation of the epic. Not included here:

- **HTTP API endpoints** for registry CRUD (install/update/disable/deprecate) and listing — `registry.py` is currently an in-process module; no blueprint/route wiring yet.
- **Persistence** — the registry is in-memory only; no DB-backed storage of installed agents/versions.
- **Frontend** — no playbook/workflow builder UI changes to show available agents/capabilities, surface compatibility problems pre-execution, or display which agent version participated in a completed run.
- **Crew execution integration** — only the existing `MultiAgentDocumentSystem` (LangGraph) workflow was wired up; no changes to any separate "crew" execution path if one exists elsewhere in the codebase.
- **Real registry catalog / install source** — no fetching of agent definitions from an external registry/marketplace; descriptors must currently be constructed and installed programmatically.
- **Run-record persistence of agent version** — the resolved version is included in the in-memory state and streamed event payload, but is not yet persisted to a `runs` table (no such table exists yet in this codebase).

## Test plan

- [x] `pytest backend/tests/test_agent_registry.py -q` — 30 passed
- [x] `python3 -m py_compile` on all touched files — passes
- [x] Confirmed pre-existing unrelated test failures (`test_config.py::test_health_keys_endpoint_exposes_only_ok_flag`, several modules needing `flask`) are present on `main` too, not introduced by this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDp718wense5Kj6ZS2x68P)_