### PR TITLE
Add multi-format chat history export (CSV, Markdown, JSON, text)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -44,9 +44,12 @@ from api_endpoints.payments.handler import (
 from api_endpoints.refresh_credits.handler import RefreshCreditsHandler
 from api_endpoints.user.handler import ViewUserHandler
 from app_helpers import (
+    SUPPORTED_EXPORT_FORMATS,
+    UnsupportedExportFormatError,
     build_callback_redirect_url,
     build_oauth_state,
     chat_history_csv_response,
+    chat_history_export_response,
     pair_chat_messages,
     reset_local_chat_artifacts,
 )
@@ -695,6 +698,62 @@ def download_chat_history():
 
         paired_messages = pair_chat_messages(messages)
         return chat_history_csv_response(paired_messages)
+    except Exception as e:
+        print("error is,", str(e))
+        return jsonify({"error": "Internal server error"}), 500
+
+
+@app.route('/export-chat-history', methods=['POST'])
+def export_chat_history():
+    """Export a chat session's history to a downloadable file.
+    ---
+    tags:
+      - Export
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          required: [chat_type, chat_id]
+          properties:
+            chat_type:
+              type: integer
+            chat_id:
+              type: integer
+            format:
+              type: string
+              description: One of csv, markdown, json, text. Defaults to csv.
+    responses:
+      200:
+        description: File download in the requested format.
+      400:
+        description: Unsupported export format.
+      401:
+        description: Invalid or missing JWT.
+      500:
+        description: Internal server error.
+    """
+    try:
+        user_email = extractUserEmailFromRequest(request)
+    except InvalidTokenError:
+        return jsonify({"error": "Invalid JWT"}), 401
+
+    body = request.get_json(silent=True) or {}
+    export_format = body.get('format', 'csv')
+
+    try:
+        chat_type = body.get('chat_type')
+        chat_id = body.get('chat_id')
+
+        messages = retrieve_message_from_db(user_email, chat_id, chat_type)
+
+        paired_messages = pair_chat_messages(messages)
+        return chat_history_export_response(paired_messages, export_format)
+    except UnsupportedExportFormatError as exc:
+        return jsonify({
+            "error": str(exc),
+            "supported_formats": list(SUPPORTED_EXPORT_FORMATS),
+        }), 400
     except Exception as e:
         print("error is,", str(e))
         return jsonify({"error": "Internal server error"}), 500

--- a/backend/app_helpers.py
+++ b/backend/app_helpers.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 import os
 import re
 import shutil
 from collections.abc import Iterable
+from datetime import datetime, timezone
 from typing import Any
 
 from flask import Response
+
+# Export formats supported by export_chat_history (issue #134 — File Export).
+SUPPORTED_EXPORT_FORMATS = ("csv", "markdown", "json", "text")
 
 
 def build_oauth_state(redirect_uri: str, product_hash: str | None, free_trial_code: str | None) -> dict[str, str]:
@@ -91,6 +96,118 @@ def chat_history_csv_response(
         mimetype="text/csv",
         headers={"Content-disposition": "attachment; filename=chat_history.csv"},
     )
+
+
+class UnsupportedExportFormatError(ValueError):
+    """Raised when a caller requests an export format we don't support."""
+
+
+def chat_history_markdown_response(
+    paired_messages: Iterable[tuple[str, str, str | None, str | None]],
+    *,
+    title: str = "Chat History",
+) -> Response:
+    """Render paired Q&A turns (with evidence chunks, if any) as Markdown.
+
+    Preserves the retrieved source chunks alongside each answer so the
+    exported file remains useful/auditable outside the app (provenance).
+    """
+    lines = [f"# {title}", "", f"_Exported: {datetime.now(timezone.utc).isoformat()}_", ""]
+    for query, response, chunk1, chunk2 in paired_messages:
+        lines.append(f"## Q: {query}")
+        lines.append("")
+        lines.append(response)
+        lines.append("")
+        chunks = [chunk for chunk in (chunk1, chunk2) if chunk]
+        if chunks:
+            lines.append("**Sources:**")
+            for chunk in chunks:
+                lines.append(f"> {chunk}")
+            lines.append("")
+    body = "\n".join(lines).rstrip() + "\n"
+    return Response(
+        body,
+        mimetype="text/markdown",
+        headers={"Content-disposition": "attachment; filename=chat_history.md"},
+    )
+
+
+def chat_history_json_response(
+    paired_messages: Iterable[tuple[str, str, str | None, str | None]],
+) -> Response:
+    """Render paired Q&A turns as a structured JSON document.
+
+    Keeps source-chunk provenance per turn so downstream tools can trace
+    answers back to the evidence used to generate them.
+    """
+    records = [
+        {
+            "query": query,
+            "response": response,
+            "sources": [chunk for chunk in (chunk1, chunk2) if chunk],
+        }
+        for query, response, chunk1, chunk2 in paired_messages
+    ]
+    payload = {
+        "exportedAt": datetime.now(timezone.utc).isoformat(),
+        "messages": records,
+    }
+    body = json.dumps(payload, indent=2, default=str)
+    return Response(
+        body,
+        mimetype="application/json",
+        headers={"Content-disposition": "attachment; filename=chat_history.json"},
+    )
+
+
+def chat_history_text_response(
+    paired_messages: Iterable[tuple[str, str, str | None, str | None]],
+) -> Response:
+    """Render paired Q&A turns as plain text."""
+    lines: list[str] = []
+    for query, response, chunk1, chunk2 in paired_messages:
+        lines.append(f"Q: {query}")
+        lines.append(f"A: {response}")
+        for chunk in (chunk1, chunk2):
+            if chunk:
+                lines.append(f"Source: {chunk}")
+        lines.append("")
+    body = "\n".join(lines).rstrip() + "\n"
+    return Response(
+        body,
+        mimetype="text/plain",
+        headers={"Content-disposition": "attachment; filename=chat_history.txt"},
+    )
+
+
+def chat_history_export_response(
+    paired_messages: Iterable[tuple[str, str, str | None, str | None]],
+    export_format: str,
+) -> Response:
+    """Dispatch to the correct chat-history export renderer by format name.
+
+    Supported formats: csv, markdown, json, text (see SUPPORTED_EXPORT_FORMATS).
+    Raises UnsupportedExportFormatError for anything else so callers can map
+    it to a 400 response.
+    """
+    fmt = (export_format or "csv").strip().lower()
+    if fmt not in SUPPORTED_EXPORT_FORMATS:
+        raise UnsupportedExportFormatError(
+            f"Unsupported export format '{export_format}'. "
+            f"Supported formats: {', '.join(SUPPORTED_EXPORT_FORMATS)}"
+        )
+
+    # paired_messages may be a one-shot generator/iterator in some call sites;
+    # materialize once so every branch below can safely consume it.
+    paired_messages = list(paired_messages)
+
+    if fmt == "csv":
+        return chat_history_csv_response(paired_messages)
+    if fmt == "markdown":
+        return chat_history_markdown_response(paired_messages)
+    if fmt == "json":
+        return chat_history_json_response(paired_messages)
+    return chat_history_text_response(paired_messages)
 
 
 def reset_local_chat_artifacts(source_documents_path: str, output_document_path: str) -> str:

--- a/backend/tests/test_app_helpers.py
+++ b/backend/tests/test_app_helpers.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 from app_helpers import (
+    SUPPORTED_EXPORT_FORMATS,
+    UnsupportedExportFormatError,
     build_callback_redirect_url,
     build_oauth_state,
     chat_history_csv_response,
+    chat_history_export_response,
+    chat_history_json_response,
+    chat_history_markdown_response,
+    chat_history_text_response,
     pair_chat_messages,
     reset_local_chat_artifacts,
 )
@@ -75,6 +82,75 @@ def test_chat_history_csv_response() -> None:
     body = response.get_data(as_text=True)
     assert "query,response,chunk1,chunk2" in body
     assert "Q1,A1,Chunk1," in body
+
+
+def test_chat_history_markdown_response() -> None:
+    response = chat_history_markdown_response(
+        [("Q1", "A1", "Chunk1", "Chunk2"), ("Q2", "A2", None, None)]
+    )
+    assert response.mimetype == "text/markdown"
+    body = response.get_data(as_text=True)
+    assert "# Chat History" in body
+    assert "## Q: Q1" in body
+    assert "A1" in body
+    assert "> Chunk1" in body
+    assert "> Chunk2" in body
+    assert "## Q: Q2" in body
+    assert "Sources" not in body.split("## Q: Q2")[1]
+
+
+def test_chat_history_json_response() -> None:
+    response = chat_history_json_response([("Q1", "A1", "Chunk1", None)])
+    assert response.mimetype == "application/json"
+    payload = json.loads(response.get_data(as_text=True))
+    assert "exportedAt" in payload
+    assert payload["messages"] == [
+        {"query": "Q1", "response": "A1", "sources": ["Chunk1"]}
+    ]
+
+
+def test_chat_history_text_response() -> None:
+    response = chat_history_text_response([("Q1", "A1", "Chunk1", "Chunk2")])
+    assert response.mimetype == "text/plain"
+    body = response.get_data(as_text=True)
+    assert "Q: Q1" in body
+    assert "A: A1" in body
+    assert "Source: Chunk1" in body
+    assert "Source: Chunk2" in body
+
+
+@pytest.mark.parametrize(
+    ("fmt", "expected_mimetype"),
+    [
+        ("csv", "text/csv"),
+        ("markdown", "text/markdown"),
+        ("json", "application/json"),
+        ("text", "text/plain"),
+        ("CSV", "text/csv"),
+        (None, "text/csv"),
+    ],
+)
+def test_chat_history_export_response_dispatch(fmt: str | None, expected_mimetype: str) -> None:
+    response = chat_history_export_response([("Q1", "A1", None, None)], fmt)
+    assert response.mimetype == expected_mimetype
+
+
+def test_chat_history_export_response_unsupported_format() -> None:
+    with pytest.raises(UnsupportedExportFormatError) as exc_info:
+        chat_history_export_response([("Q1", "A1", None, None)], "pdf")
+    assert "pdf" in str(exc_info.value)
+    for fmt in SUPPORTED_EXPORT_FORMATS:
+        assert fmt in str(exc_info.value)
+
+
+def test_chat_history_export_response_consumes_generator_once() -> None:
+    def _gen():
+        yield ("Q1", "A1", None, None)
+        yield ("Q2", "A2", None, None)
+
+    response = chat_history_export_response(_gen(), "json")
+    payload = json.loads(response.get_data(as_text=True))
+    assert len(payload["messages"]) == 2
 
 
 def test_reset_local_chat_artifacts(tmp_path: Path) -> None:

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -314,6 +314,79 @@ def test_download_chat_history_invalid_token_and_error(
 
 
 @pytest.mark.parametrize(
+    ("export_format", "expected_mimetype"),
+    [
+        ("csv", "text/csv"),
+        ("markdown", "text/markdown"),
+        ("json", "application/json"),
+        ("text", "text/plain"),
+    ],
+)
+def test_export_chat_history_formats(
+    client: Any,
+    app_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    auth_headers: dict[str, str],
+    export_format: str,
+    expected_mimetype: str,
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    messages = [
+        {"sent_from_user": 1, "message_text": "Hi", "relevant_chunks": None},
+        {"sent_from_user": 0, "message_text": "Hello", "relevant_chunks": "Document: Sample: Paragraph"},
+    ]
+    monkeypatch.setattr(app_module, "retrieve_message_from_db", lambda *args: messages)
+    response = client.post(
+        "/export-chat-history",
+        json={"chat_type": 0, "chat_id": 9, "format": export_format},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.mimetype == expected_mimetype
+
+
+def test_export_chat_history_defaults_to_csv(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    monkeypatch.setattr(app_module, "retrieve_message_from_db", lambda *args: [])
+    response = client.post("/export-chat-history", json={"chat_type": 0, "chat_id": 9}, headers=auth_headers)
+    assert response.status_code == 200
+    assert response.mimetype == "text/csv"
+
+
+def test_export_chat_history_unsupported_format(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    monkeypatch.setattr(app_module, "retrieve_message_from_db", lambda *args: [])
+    response = client.post(
+        "/export-chat-history",
+        json={"chat_type": 0, "chat_id": 9, "format": "pdf"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400
+    body = response.get_json()
+    assert "pdf" in body["error"]
+    assert set(body["supported_formats"]) == {"csv", "markdown", "json", "text"}
+
+
+def test_export_chat_history_invalid_token_and_error(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+) -> None:
+    _invalidate_token(monkeypatch, app_module)
+    invalid_response = client.post("/export-chat-history", json={"chat_type": 0, "chat_id": 9}, headers=auth_headers)
+    assert invalid_response.status_code == 401
+    assert invalid_response.get_json() == {"error": "Invalid JWT"}
+
+    _authenticate(monkeypatch, app_module)
+    monkeypatch.setattr(app_module, "retrieve_message_from_db", lambda *args: None)
+    error_response = client.post("/export-chat-history", json={"chat_type": 0, "chat_id": 9}, headers=auth_headers)
+    assert error_response.status_code == 500
+    assert error_response.get_json()["error"] == "Internal server error"
+
+
+@pytest.mark.parametrize(
     ("endpoint", "handler_name", "payload", "expected_json", "expected_text"),
     [
         ("/create-new-chat", "CreateNewChatHandler", {"chat_type": 0, "model_type": 0}, {"chat_id": 1}, None),


### PR DESCRIPTION
## Summary
Addresses #134 — implements the **file export** piece of the larger export/downstream-delivery epic, scoped to the existing chat-history download flow.

- New `POST /export-chat-history` endpoint accepting `chat_type`, `chat_id`, and an optional `format` (`csv`, `markdown`, `json`, `text`; defaults to `csv`).
- New per-format renderers in `backend/app_helpers.py`: `chat_history_markdown_response`, `chat_history_json_response`, `chat_history_text_response`, plus a `chat_history_export_response` dispatcher and `UnsupportedExportFormatError` → 400 with the list of supported formats.
- Each export preserves the retrieved source chunks per Q&A turn so exported files remain useful/auditable outside the app (provenance).
- Tests added in `test_app_helpers.py` and `test_routes.py` covering all four formats, the default format, the unsupported-format error path, and auth/error handling. 17/17 relevant tests pass.

## Out of scope (follow-up)
- Export of other artifact types (workflow outputs, reports, plans) — this PR only covers chat history.
- PDF rendering.
- Downstream delivery integrations (email, Slack/webhook, Google Docs/Sheets, Notion).
- Export history/status UI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDp718wense5Kj6ZS2x68P)_