### PR TITLE
Add persisted agent-run data model and operator-console REST API

### DIFF
--- a/backend/alembic/versions/0003_agent_runs.py
+++ b/backend/alembic/versions/0003_agent_runs.py
@@ -1,0 +1,69 @@
+"""Operator console foundation: agent_runs + agent_run_events (issue #140)
+
+Adds the persisted data model behind the operator console epic — a place to
+track autonomous "runs" (project/queue/live/historical) along with status,
+current step, blockers, cost, and an audit trail of human intervention
+events (pause/resume/cancel/retry/message). The frontend operator console
+(and the REST endpoints in api_endpoints/agent_runs/) build on these tables.
+
+This migration only adds tables; nothing writes to them until the new
+/api/agent-runs endpoints are exercised, so it is inert for existing flows.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-06-20 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS agent_runs (
+            id INTEGER PRIMARY KEY AUTO_INCREMENT,
+            created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            user_id INTEGER NOT NULL,
+            chat_id INTEGER DEFAULT NULL,
+            project_name VARCHAR(255) NOT NULL,
+            status VARCHAR(32) NOT NULL DEFAULT 'queued',
+            current_step TEXT,
+            blocker TEXT,
+            cost_usd DECIMAL(10, 4) NOT NULL DEFAULT 0,
+            started_at TIMESTAMP DEFAULT NULL,
+            finished_at TIMESTAMP DEFAULT NULL,
+            summary TEXT,
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            FOREIGN KEY (chat_id) REFERENCES chats(id)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS agent_run_events (
+            id INTEGER PRIMARY KEY AUTO_INCREMENT,
+            created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            run_id INTEGER NOT NULL,
+            event_type VARCHAR(32) NOT NULL,
+            actor VARCHAR(255),
+            message TEXT,
+            FOREIGN KEY (run_id) REFERENCES agent_runs(id)
+        )
+        """
+    )
+    op.execute("CREATE INDEX idx_agent_runs_user_id ON agent_runs(user_id)")
+    op.execute("CREATE INDEX idx_agent_runs_status ON agent_runs(status)")
+    op.execute("CREATE INDEX idx_agent_run_events_run_id ON agent_run_events(run_id)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS agent_run_events")
+    op.execute("DROP TABLE IF EXISTS agent_runs")

--- a/backend/api_endpoints/agent_runs/handler.py
+++ b/backend/api_endpoints/agent_runs/handler.py
@@ -1,0 +1,147 @@
+"""HTTP handlers for the operator console — issue #140 (slice 1).
+
+These handlers back a small REST surface for autonomous "runs": list/create,
+fetch a single run, fetch its audit trail, and apply an operator
+intervention (pause/resume/cancel/retry/message). The Flask routes in
+``app.py`` resolve the authenticated user and delegate to these functions,
+mirroring the pattern used by ``api_endpoints/documents/handler.py``.
+
+Scope: this slice ships the persisted data model + control API only. The
+dashboard UI (project list, live run view, daily/overnight summary screens)
+is explicitly out of scope here — see the PR description for the rest of
+the epic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from database.agent_runs import (
+    apply_intervention,
+    create_run,
+    get_run,
+    list_run_events,
+    list_runs,
+)
+from database.db_auth import user_id_for_email
+from flask import Request, jsonify
+from flask.typing import ResponseReturnValue
+
+_VALID_INTERVENTIONS = {"pause", "resume", "cancel", "retry", "message"}
+
+
+def _resolve_user_id(user_email: str) -> int | None:
+    return user_id_for_email(user_email)
+
+
+def CreateRunHandler(request: Request, user_email: str) -> ResponseReturnValue:
+    """POST /api/agent-runs — queue a new autonomous run."""
+    body = request.get_json(silent=True) or {}
+    project_name = (body.get("project_name") or "").strip()
+    chat_id = body.get("chat_id")
+
+    if not project_name:
+        return jsonify({"error": "project_name is required"}), 400
+
+    user_id = _resolve_user_id(user_email)
+    if user_id is None:
+        return jsonify({"error": "User not found"}), 404
+
+    run_id = create_run(user_id, project_name, chat_id=chat_id)
+    run = get_run(run_id, user_id)
+    return jsonify(_serialize_run(run)), 201
+
+
+def ListRunsHandler(request: Request, user_email: str) -> ResponseReturnValue:
+    """GET /api/agent-runs — list runs for the operator console's queue/history views."""
+    user_id = _resolve_user_id(user_email)
+    if user_id is None:
+        return jsonify({"error": "User not found"}), 404
+
+    status = request.args.get("status")
+    try:
+        limit = int(request.args.get("limit", 50))
+    except (TypeError, ValueError):
+        limit = 50
+
+    runs = list_runs(user_id, status=status, limit=limit)
+    return jsonify({"runs": [_serialize_run(r) for r in runs]}), 200
+
+
+def GetRunHandler(request: Request, user_email: str, run_id: int) -> ResponseReturnValue:
+    """GET /api/agent-runs/<run_id> — live run detail view."""
+    user_id = _resolve_user_id(user_email)
+    if user_id is None:
+        return jsonify({"error": "User not found"}), 404
+
+    run = get_run(run_id, user_id)
+    if run is None:
+        return jsonify({"error": "Run not found"}), 404
+    return jsonify(_serialize_run(run)), 200
+
+
+def GetRunEventsHandler(request: Request, user_email: str, run_id: int) -> ResponseReturnValue:
+    """GET /api/agent-runs/<run_id>/events — audit trail of interventions."""
+    user_id = _resolve_user_id(user_email)
+    if user_id is None:
+        return jsonify({"error": "User not found"}), 404
+
+    run = get_run(run_id, user_id)
+    if run is None:
+        return jsonify({"error": "Run not found"}), 404
+
+    events = list_run_events(run_id, user_id)
+    return jsonify({"events": [_serialize_event(e) for e in events]}), 200
+
+
+def InterventionHandler(request: Request, user_email: str, run_id: int) -> ResponseReturnValue:
+    """POST /api/agent-runs/<run_id>/intervene — pause/resume/cancel/retry/message.
+
+    Body: {"action": "pause" | "resume" | "cancel" | "retry" | "message",
+           "message": "..."}  (message only required/used for action=message)
+    """
+    user_id = _resolve_user_id(user_email)
+    if user_id is None:
+        return jsonify({"error": "User not found"}), 404
+
+    body = request.get_json(silent=True) or {}
+    action = (body.get("action") or "").strip()
+    message = body.get("message")
+
+    if action not in _VALID_INTERVENTIONS:
+        return jsonify({
+            "error": f"Invalid action {action!r}. Must be one of {sorted(_VALID_INTERVENTIONS)}."
+        }), 400
+
+    if action == "message" and not message:
+        return jsonify({"error": "message is required for action=message"}), 400
+
+    try:
+        result = apply_intervention(run_id, user_id, action, actor=user_email, message=message)
+    except ValueError as exc:
+        msg = str(exc)
+        status_code = 404 if "not found" in msg.lower() else 400
+        return jsonify({"error": msg}), status_code
+
+    return jsonify(result), 200
+
+
+def _serialize_run(run: dict[str, Any] | None) -> dict[str, Any] | None:
+    if run is None:
+        return None
+    out = dict(run)
+    for key in ("created", "updated", "started_at", "finished_at"):
+        value = out.get(key)
+        if hasattr(value, "isoformat"):
+            out[key] = value.isoformat()
+    if out.get("cost_usd") is not None:
+        out["cost_usd"] = float(out["cost_usd"])
+    return out
+
+
+def _serialize_event(event: dict[str, Any]) -> dict[str, Any]:
+    out = dict(event)
+    value = out.get("created")
+    if hasattr(value, "isoformat"):
+        out["created"] = value.isoformat()
+    return out

--- a/backend/app.py
+++ b/backend/app.py
@@ -21,6 +21,13 @@ from api_endpoints.chat.handler import (
     UpdateChatNameHandler,
 )
 from api_endpoints.delete_api_key.handler import DeleteAPIKeyHandler
+from api_endpoints.agent_runs.handler import (
+    CreateRunHandler,
+    GetRunEventsHandler,
+    GetRunHandler,
+    InterventionHandler,
+    ListRunsHandler,
+)
 from api_endpoints.documents.handler import (
     ChangeChatModeHandler,
     DeleteDocHandler,
@@ -885,6 +892,61 @@ def reset_chat():
     # If the JWT is invalid, return an error
         return jsonify({"error": "Invalid JWT"}), 401
     return ResetChatHandler(request, user_email)
+
+
+# ---------------------------------------------------------------------------
+# Operator console — runs + interventions (issue #140, slice 1)
+# ---------------------------------------------------------------------------
+# Persisted backbone for the operator console epic: lets a human operator
+# list/queue runs, inspect a single run's live status, review its audit
+# trail, and issue pause/resume/cancel/retry/message-the-agent controls
+# without direct database access. The dashboard UI that consumes these
+# endpoints is tracked separately as a follow-up.
+
+@app.route('/api/agent-runs', methods=['POST'])
+def create_agent_run():
+    try:
+        user_email = extractUserEmailFromRequest(request)
+    except InvalidTokenError:
+        return jsonify({"error": "Invalid JWT"}), 401
+    return CreateRunHandler(request, user_email)
+
+
+@app.route('/api/agent-runs', methods=['GET'])
+def list_agent_runs():
+    try:
+        user_email = extractUserEmailFromRequest(request)
+    except InvalidTokenError:
+        return jsonify({"error": "Invalid JWT"}), 401
+    return ListRunsHandler(request, user_email)
+
+
+@app.route('/api/agent-runs/<int:run_id>', methods=['GET'])
+def get_agent_run(run_id):
+    try:
+        user_email = extractUserEmailFromRequest(request)
+    except InvalidTokenError:
+        return jsonify({"error": "Invalid JWT"}), 401
+    return GetRunHandler(request, user_email, run_id)
+
+
+@app.route('/api/agent-runs/<int:run_id>/events', methods=['GET'])
+def get_agent_run_events(run_id):
+    try:
+        user_email = extractUserEmailFromRequest(request)
+    except InvalidTokenError:
+        return jsonify({"error": "Invalid JWT"}), 401
+    return GetRunEventsHandler(request, user_email, run_id)
+
+
+@app.route('/api/agent-runs/<int:run_id>/intervene', methods=['POST'])
+def intervene_on_agent_run(run_id):
+    try:
+        user_email = extractUserEmailFromRequest(request)
+    except InvalidTokenError:
+        return jsonify({"error": "Invalid JWT"}), 401
+    return InterventionHandler(request, user_email, run_id)
+
 
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, o):

--- a/backend/database/agent_runs.py
+++ b/backend/database/agent_runs.py
@@ -1,0 +1,320 @@
+"""Operator console data access — issue #140 (slice 1: runs + interventions).
+
+This is the persisted backbone for the operator console epic: a human
+operator needs to list projects/runs, monitor a run's live status, and
+issue pause / resume / cancel / retry / message-the-agent controls without
+direct database access. Every control action is recorded as an
+``agent_run_events`` row so the audit trail required by the issue's
+acceptance criteria ("Intervention events are persisted and visible in the
+audit trail") is satisfiable.
+
+Design notes
+------------
+- Mirrors the raw-cursor style already used in ``database/db.py`` /
+  ``database/qa_feedback.py`` rather than the SQLAlchemy ORM, since the rest
+  of the write path for chats/messages uses the connection pool directly.
+- Status machine is intentionally small: queued -> running -> (paused) ->
+  running -> (completed | failed | canceled). Invalid transitions raise
+  ``ValueError`` so the API layer can return a 400 instead of silently
+  corrupting state.
+- All cost is accumulated in ``cost_usd`` via ``increment_run_cost`` so the
+  "cost" column required by the issue's acceptance criteria stays accurate
+  across multiple agent steps.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from database.db_pool import get_db_connection
+
+# ---------------------------------------------------------------------------
+# Status machine
+# ---------------------------------------------------------------------------
+
+ACTIVE_STATUSES = {"queued", "running", "paused"}
+TERMINAL_STATUSES = {"completed", "failed", "canceled"}
+ALL_STATUSES = ACTIVE_STATUSES | TERMINAL_STATUSES
+
+# event_type -> (allowed current statuses, resulting status)
+_TRANSITIONS: dict[str, tuple[set[str], str]] = {
+    "pause": ({"queued", "running"}, "paused"),
+    "resume": ({"paused"}, "running"),
+    "cancel": (ACTIVE_STATUSES, "canceled"),
+    "retry": ({"failed", "canceled"}, "queued"),
+}
+
+
+def create_run(
+    user_id: int,
+    project_name: str,
+    chat_id: int | None = None,
+) -> int:
+    """Create a new run in 'queued' status and return its id."""
+    conn, cursor = get_db_connection()
+    try:
+        cursor.execute(
+            """
+            INSERT INTO agent_runs (user_id, chat_id, project_name, status)
+            VALUES (%s, %s, %s, 'queued')
+            """,
+            [user_id, chat_id, project_name],
+        )
+        conn.commit()
+        run_id = cursor.lastrowid
+        _log_event(cursor, conn, run_id, "created", actor=None, message=f"Run '{project_name}' queued.")
+        return run_id
+    finally:
+        conn.close()
+
+
+def get_run(run_id: int, user_id: int) -> dict[str, Any] | None:
+    """Fetch a single run scoped to its owning user."""
+    conn, cursor = get_db_connection()
+    try:
+        cursor.execute(
+            "SELECT * FROM agent_runs WHERE id = %s AND user_id = %s",
+            [run_id, user_id],
+        )
+        return cursor.fetchone()
+    finally:
+        conn.close()
+
+
+def list_runs(
+    user_id: int,
+    status: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """List runs for a user, optionally filtered by status, newest first."""
+    limit = max(1, min(int(limit), 200))
+    conn, cursor = get_db_connection()
+    try:
+        if status:
+            cursor.execute(
+                """
+                SELECT * FROM agent_runs
+                WHERE user_id = %s AND status = %s
+                ORDER BY created DESC
+                LIMIT %s
+                """,
+                [user_id, status, limit],
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT * FROM agent_runs
+                WHERE user_id = %s
+                ORDER BY created DESC
+                LIMIT %s
+                """,
+                [user_id, limit],
+            )
+        return cursor.fetchall()
+    finally:
+        conn.close()
+
+
+def update_run_progress(
+    run_id: int,
+    user_id: int,
+    *,
+    status: str | None = None,
+    current_step: str | None = None,
+    blocker: str | None = None,
+    summary: str | None = None,
+) -> bool:
+    """Update live progress fields (status, current step, blocker, summary).
+
+    Used by the agent execution loop to report progress; not a substitute
+    for the intervention transitions in ``apply_intervention`` (those go
+    through the status machine and write an audit event).
+    """
+    fields: list[str] = []
+    values: list[Any] = []
+
+    if status is not None:
+        if status not in ALL_STATUSES:
+            raise ValueError(f"Unknown status: {status!r}")
+        fields.append("status = %s")
+        values.append(status)
+        if status == "running":
+            fields.append("started_at = COALESCE(started_at, CURRENT_TIMESTAMP)")
+        if status in TERMINAL_STATUSES:
+            fields.append("finished_at = CURRENT_TIMESTAMP")
+    if current_step is not None:
+        fields.append("current_step = %s")
+        values.append(current_step)
+    if blocker is not None:
+        fields.append("blocker = %s")
+        values.append(blocker)
+    if summary is not None:
+        fields.append("summary = %s")
+        values.append(summary)
+
+    if not fields:
+        return False
+
+    fields.append("updated = CURRENT_TIMESTAMP")
+    values.extend([run_id, user_id])
+
+    conn, cursor = get_db_connection()
+    try:
+        cursor.execute(
+            f"UPDATE agent_runs SET {', '.join(fields)} WHERE id = %s AND user_id = %s",
+            values,
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+    finally:
+        conn.close()
+
+
+def increment_run_cost(run_id: int, user_id: int, delta_usd: float) -> bool:
+    """Add ``delta_usd`` to the run's accumulated cost."""
+    conn, cursor = get_db_connection()
+    try:
+        cursor.execute(
+            """
+            UPDATE agent_runs
+            SET cost_usd = cost_usd + %s, updated = CURRENT_TIMESTAMP
+            WHERE id = %s AND user_id = %s
+            """,
+            [delta_usd, run_id, user_id],
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+    finally:
+        conn.close()
+
+
+def apply_intervention(
+    run_id: int,
+    user_id: int,
+    event_type: str,
+    actor: str | None = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    """Apply an operator intervention (pause/resume/cancel/retry/message).
+
+    Validates the transition against the current status, updates the run,
+    and persists an ``agent_run_events`` row — this is what makes
+    interventions visible in the audit trail per the issue's acceptance
+    criteria. Raises ``ValueError`` for an unknown run or an invalid
+    transition; callers should translate that into a 404/400.
+    """
+    if event_type == "message":
+        # Messaging the agent doesn't change status — just logs an event
+        # the live-run consumer (e.g. the agent loop) can pick up.
+        conn, cursor = get_db_connection()
+        try:
+            cursor.execute(
+                "SELECT id FROM agent_runs WHERE id = %s AND user_id = %s",
+                [run_id, user_id],
+            )
+            if cursor.fetchone() is None:
+                raise ValueError(f"Run {run_id} not found.")
+            _log_event(cursor, conn, run_id, "message", actor=actor, message=message)
+            return {"run_id": run_id, "event_type": "message", "status": None}
+        finally:
+            conn.close()
+
+    if event_type not in _TRANSITIONS:
+        raise ValueError(
+            f"Unknown intervention type: {event_type!r}. "
+            f"Expected one of: {sorted(_TRANSITIONS) + ['message']}"
+        )
+
+    allowed_from, new_status = _TRANSITIONS[event_type]
+
+    conn, cursor = get_db_connection()
+    try:
+        cursor.execute(
+            "SELECT status FROM agent_runs WHERE id = %s AND user_id = %s",
+            [run_id, user_id],
+        )
+        row = cursor.fetchone()
+        if row is None:
+            raise ValueError(f"Run {run_id} not found.")
+
+        current_status = row["status"]
+        if current_status not in allowed_from:
+            raise ValueError(
+                f"Cannot {event_type} a run in status {current_status!r}. "
+                f"Allowed from: {sorted(allowed_from)}"
+            )
+
+        if new_status in TERMINAL_STATUSES:
+            cursor.execute(
+                """
+                UPDATE agent_runs
+                SET status = %s, updated = CURRENT_TIMESTAMP, finished_at = CURRENT_TIMESTAMP
+                WHERE id = %s AND user_id = %s
+                """,
+                [new_status, run_id, user_id],
+            )
+        elif new_status == "running":
+            cursor.execute(
+                """
+                UPDATE agent_runs
+                SET status = %s, updated = CURRENT_TIMESTAMP,
+                    started_at = COALESCE(started_at, CURRENT_TIMESTAMP)
+                WHERE id = %s AND user_id = %s
+                """,
+                [new_status, run_id, user_id],
+            )
+        else:
+            cursor.execute(
+                "UPDATE agent_runs SET status = %s, updated = CURRENT_TIMESTAMP WHERE id = %s AND user_id = %s",
+                [new_status, run_id, user_id],
+            )
+        conn.commit()
+
+        _log_event(cursor, conn, run_id, event_type, actor=actor, message=message)
+        return {"run_id": run_id, "event_type": event_type, "status": new_status}
+    finally:
+        conn.close()
+
+
+def list_run_events(run_id: int, user_id: int, limit: int = 100) -> list[dict[str, Any]]:
+    """Return the audit trail of intervention events for a run, newest first."""
+    limit = max(1, min(int(limit), 500))
+    conn, cursor = get_db_connection()
+    try:
+        cursor.execute(
+            "SELECT id FROM agent_runs WHERE id = %s AND user_id = %s",
+            [run_id, user_id],
+        )
+        if cursor.fetchone() is None:
+            return []
+        cursor.execute(
+            """
+            SELECT * FROM agent_run_events
+            WHERE run_id = %s
+            ORDER BY created DESC
+            LIMIT %s
+            """,
+            [run_id, limit],
+        )
+        return cursor.fetchall()
+    finally:
+        conn.close()
+
+
+def _log_event(
+    cursor: Any,
+    conn: Any,
+    run_id: int,
+    event_type: str,
+    actor: str | None,
+    message: str | None,
+) -> None:
+    """Insert one audit-trail row and commit. Caller owns the connection."""
+    cursor.execute(
+        """
+        INSERT INTO agent_run_events (run_id, event_type, actor, message)
+        VALUES (%s, %s, %s, %s)
+        """,
+        [run_id, event_type, actor, message],
+    )
+    conn.commit()

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -6,6 +6,8 @@ DROP TABLE IF EXISTS prompts;
 DROP TABLE IF EXISTS chunks;
 DROP TABLE IF EXISTS documents;
 DROP TABLE IF EXISTS qa_feedback;
+DROP TABLE IF EXISTS agent_run_events;
+DROP TABLE IF EXISTS agent_runs;
 DROP TABLE IF EXISTS messages;
 DROP TABLE IF EXISTS chat_share_chunks;
 DROP TABLE IF EXISTS chat_share_documents;
@@ -153,6 +155,37 @@ CREATE TABLE qa_feedback (
     FOREIGN KEY (chat_id) REFERENCES chats(id)
 );
 
+-- Operator console (issue #140): persisted autonomous "runs" so a human
+-- operator can monitor and control agent execution without DB access, plus
+-- an audit trail of intervention events (pause/resume/cancel/retry/message).
+CREATE TABLE agent_runs (
+    id INTEGER PRIMARY KEY AUTO_INCREMENT,
+    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    user_id INTEGER NOT NULL,
+    chat_id INTEGER DEFAULT(NULL),
+    project_name VARCHAR(255) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'queued',
+    current_step TEXT,
+    blocker TEXT,
+    cost_usd DECIMAL(10, 4) NOT NULL DEFAULT 0,
+    started_at TIMESTAMP DEFAULT(NULL),
+    finished_at TIMESTAMP DEFAULT(NULL),
+    summary TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (chat_id) REFERENCES chats(id)
+);
+
+CREATE TABLE agent_run_events (
+    id INTEGER PRIMARY KEY AUTO_INCREMENT,
+    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    run_id INTEGER NOT NULL,
+    event_type VARCHAR(32) NOT NULL,
+    actor VARCHAR(255),
+    message TEXT,
+    FOREIGN KEY (run_id) REFERENCES agent_runs(id)
+);
+
 -- Stores media files attached to user messages (images, audio clips, video clips)
 CREATE TABLE message_attachments (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
@@ -263,3 +296,6 @@ CREATE INDEX idx_api_usage_user_id  ON api_usage(user_id);
 CREATE INDEX idx_api_usage_key_id   ON api_usage(api_key_id);
 CREATE INDEX idx_api_usage_created  ON api_usage(created);
 CREATE INDEX idx_qa_feedback_chat_id ON qa_feedback(chat_id);
+CREATE INDEX idx_agent_runs_user_id ON agent_runs(user_id);
+CREATE INDEX idx_agent_runs_status ON agent_runs(status);
+CREATE INDEX idx_agent_run_events_run_id ON agent_run_events(run_id);

--- a/backend/tests/test_agent_runs.py
+++ b/backend/tests/test_agent_runs.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from database import agent_runs
+
+
+@pytest.fixture()
+def db_connection(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, MagicMock]:
+    connection = MagicMock()
+    cursor = MagicMock()
+    monkeypatch.setattr(agent_runs, "get_db_connection", lambda: (connection, cursor))
+    return connection, cursor
+
+
+# ---------------------------------------------------------------------------
+# create_run / get_run / list_runs
+# ---------------------------------------------------------------------------
+
+
+def test_create_run_inserts_and_logs_event(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    connection, cursor = db_connection
+    cursor.lastrowid = 42
+    run_id = agent_runs.create_run(user_id=1, project_name="Nightly ingest")
+
+    assert run_id == 42
+    # one INSERT for the run, one INSERT for the audit event
+    assert cursor.execute.call_count == 2
+    assert "INSERT INTO agent_runs" in cursor.execute.call_args_list[0].args[0]
+    assert "INSERT INTO agent_run_events" in cursor.execute.call_args_list[1].args[0]
+    assert connection.commit.call_count == 2
+    assert connection.close.called
+
+
+def test_get_run_scopes_by_user(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = {"id": 5, "user_id": 1, "status": "running"}
+    run = agent_runs.get_run(5, user_id=1)
+    assert run == {"id": 5, "user_id": 1, "status": "running"}
+    assert cursor.execute.call_args.args[1] == [5, 1]
+
+
+def test_list_runs_filters_by_status(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchall.return_value = [{"id": 1, "status": "paused"}]
+    runs = agent_runs.list_runs(user_id=1, status="paused", limit=10)
+    assert runs == [{"id": 1, "status": "paused"}]
+    sql, params = cursor.execute.call_args.args
+    assert "WHERE user_id = %s AND status = %s" in sql
+    assert params == [1, "paused", 10]
+
+
+def test_list_runs_clamps_limit(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchall.return_value = []
+    agent_runs.list_runs(user_id=1, limit=10_000)
+    _, params = cursor.execute.call_args.args
+    assert params[-1] == 200  # clamped to max
+
+
+# ---------------------------------------------------------------------------
+# update_run_progress / increment_run_cost
+# ---------------------------------------------------------------------------
+
+
+def test_update_run_progress_sets_started_at_on_running(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    connection, cursor = db_connection
+    cursor.rowcount = 1
+    updated = agent_runs.update_run_progress(1, user_id=1, status="running", current_step="Step 2")
+    assert updated is True
+    sql = cursor.execute.call_args.args[0]
+    assert "started_at = COALESCE(started_at, CURRENT_TIMESTAMP)" in sql
+    connection.commit.assert_called_once()
+
+
+def test_update_run_progress_sets_finished_at_on_terminal_status(
+    db_connection: tuple[MagicMock, MagicMock]
+) -> None:
+    _, cursor = db_connection
+    cursor.rowcount = 1
+    agent_runs.update_run_progress(1, user_id=1, status="completed")
+    sql = cursor.execute.call_args.args[0]
+    assert "finished_at = CURRENT_TIMESTAMP" in sql
+
+
+def test_update_run_progress_rejects_unknown_status(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    with pytest.raises(ValueError):
+        agent_runs.update_run_progress(1, user_id=1, status="bogus")
+
+
+def test_update_run_progress_no_fields_returns_false(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    assert agent_runs.update_run_progress(1, user_id=1) is False
+
+
+def test_increment_run_cost(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    connection, cursor = db_connection
+    cursor.rowcount = 1
+    assert agent_runs.increment_run_cost(1, user_id=1, delta_usd=0.25) is True
+    connection.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# apply_intervention — the status machine + audit trail
+# ---------------------------------------------------------------------------
+
+
+def test_apply_intervention_pause_running_run(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    connection, cursor = db_connection
+    cursor.fetchone.return_value = {"status": "running"}
+
+    result = agent_runs.apply_intervention(1, user_id=1, event_type="pause", actor="op@example.com")
+
+    assert result == {"run_id": 1, "event_type": "pause", "status": "paused"}
+    # SELECT status, UPDATE status, INSERT event
+    assert cursor.execute.call_count == 3
+    assert connection.commit.call_count == 2
+
+
+def test_apply_intervention_resume_paused_run(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = {"status": "paused"}
+    result = agent_runs.apply_intervention(1, user_id=1, event_type="resume")
+    assert result["status"] == "running"
+
+
+def test_apply_intervention_rejects_invalid_transition(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = {"status": "completed"}
+    with pytest.raises(ValueError, match="Cannot pause"):
+        agent_runs.apply_intervention(1, user_id=1, event_type="pause")
+
+
+def test_apply_intervention_missing_run_raises(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = None
+    with pytest.raises(ValueError, match="not found"):
+        agent_runs.apply_intervention(999, user_id=1, event_type="pause")
+
+
+def test_apply_intervention_unknown_type_raises(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = {"status": "running"}
+    with pytest.raises(ValueError, match="Unknown intervention type"):
+        agent_runs.apply_intervention(1, user_id=1, event_type="explode")
+
+
+def test_apply_intervention_message_does_not_change_status(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    connection, cursor = db_connection
+    cursor.fetchone.return_value = {"id": 1}
+
+    result = agent_runs.apply_intervention(
+        1, user_id=1, event_type="message", actor="op@example.com", message="Please pivot strategy"
+    )
+
+    assert result == {"run_id": 1, "event_type": "message", "status": None}
+    insert_sql = cursor.execute.call_args_list[-1].args[0]
+    assert "INSERT INTO agent_run_events" in insert_sql
+    connection.commit.assert_called()
+
+
+def test_apply_intervention_message_missing_run_raises(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = None
+    with pytest.raises(ValueError, match="not found"):
+        agent_runs.apply_intervention(999, user_id=1, event_type="message", message="hi")
+
+
+def test_apply_intervention_cancel_from_queued(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = {"status": "queued"}
+    result = agent_runs.apply_intervention(1, user_id=1, event_type="cancel")
+    assert result["status"] == "canceled"
+
+
+def test_apply_intervention_retry_from_failed(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = {"status": "failed"}
+    result = agent_runs.apply_intervention(1, user_id=1, event_type="retry")
+    assert result["status"] == "queued"
+
+
+# ---------------------------------------------------------------------------
+# list_run_events
+# ---------------------------------------------------------------------------
+
+
+def test_list_run_events_returns_empty_for_missing_run(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = None
+    assert agent_runs.list_run_events(1, user_id=1) == []
+
+
+def test_list_run_events_returns_rows_for_owned_run(db_connection: tuple[MagicMock, MagicMock]) -> None:
+    _, cursor = db_connection
+    cursor.fetchone.return_value = {"id": 1}
+    cursor.fetchall.return_value = [{"id": 1, "event_type": "pause"}]
+    events = agent_runs.list_run_events(1, user_id=1)
+    assert events == [{"id": 1, "event_type": "pause"}]

--- a/backend/tests/test_agent_runs_routes.py
+++ b/backend/tests/test_agent_runs_routes.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def _authenticate(monkeypatch: pytest.MonkeyPatch, app_module: Any, email: str = "test@example.com") -> None:
+    monkeypatch.setattr(app_module, "extractUserEmailFromRequest", lambda request: email)
+
+
+def _invalidate_token(monkeypatch: pytest.MonkeyPatch, app_module: Any) -> None:
+    def _raise_invalid(request: Any) -> str:
+        raise app_module.InvalidTokenError()
+
+    monkeypatch.setattr(app_module, "extractUserEmailFromRequest", _raise_invalid)
+
+
+def test_create_agent_run_requires_auth(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    _invalidate_token(monkeypatch, app_module)
+    response = client.post("/api/agent-runs", json={"project_name": "Nightly run"})
+    assert response.status_code == 401
+
+
+def test_create_agent_run_requires_project_name(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    response = client.post("/api/agent-runs", json={})
+    assert response.status_code == 400
+
+
+def test_create_agent_run_unknown_user_returns_404(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: None)
+    response = client.post("/api/agent-runs", json={"project_name": "Nightly run"})
+    assert response.status_code == 404
+
+
+def test_create_and_get_agent_run_roundtrip(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+    monkeypatch.setattr(handler, "create_run", lambda user_id, project_name, chat_id=None: 99)
+    fake_run = {
+        "id": 99,
+        "user_id": 7,
+        "project_name": "Nightly run",
+        "status": "queued",
+        "cost_usd": 0,
+        "created": None,
+        "updated": None,
+        "started_at": None,
+        "finished_at": None,
+    }
+    monkeypatch.setattr(handler, "get_run", lambda run_id, user_id: fake_run)
+
+    response = client.post("/api/agent-runs", json={"project_name": "Nightly run"})
+    assert response.status_code == 201
+    body = response.get_json()
+    assert body["id"] == 99
+    assert body["status"] == "queued"
+
+    response = client.get("/api/agent-runs/99")
+    assert response.status_code == 200
+    assert response.get_json()["project_name"] == "Nightly run"
+
+
+def test_get_agent_run_not_found(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+    monkeypatch.setattr(handler, "get_run", lambda run_id, user_id: None)
+
+    response = client.get("/api/agent-runs/123")
+    assert response.status_code == 404
+
+
+def test_list_agent_runs(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+    monkeypatch.setattr(
+        handler,
+        "list_runs",
+        lambda user_id, status=None, limit=50: [
+            {"id": 1, "status": "running", "cost_usd": 1.5, "created": None, "updated": None,
+             "started_at": None, "finished_at": None}
+        ],
+    )
+
+    response = client.get("/api/agent-runs?status=running")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert len(body["runs"]) == 1
+    assert body["runs"][0]["cost_usd"] == 1.5
+
+
+def test_intervention_invalid_action_returns_400(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+
+    response = client.post("/api/agent-runs/1/intervene", json={"action": "explode"})
+    assert response.status_code == 400
+
+
+def test_intervention_message_requires_message_body(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+
+    response = client.post("/api/agent-runs/1/intervene", json={"action": "message"})
+    assert response.status_code == 400
+
+
+def test_intervention_pause_success(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+    monkeypatch.setattr(
+        handler,
+        "apply_intervention",
+        lambda run_id, user_id, event_type, actor=None, message=None: {
+            "run_id": run_id, "event_type": event_type, "status": "paused"
+        },
+    )
+
+    response = client.post("/api/agent-runs/1/intervene", json={"action": "pause"})
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "paused"
+
+
+def test_intervention_invalid_transition_returns_400(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise ValueError("Cannot pause a run in status 'completed'.")
+
+    monkeypatch.setattr(handler, "apply_intervention", _raise)
+
+    response = client.post("/api/agent-runs/1/intervene", json={"action": "pause"})
+    assert response.status_code == 400
+
+
+def test_intervention_missing_run_returns_404(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise ValueError("Run 999 not found.")
+
+    monkeypatch.setattr(handler, "apply_intervention", _raise)
+
+    response = client.post("/api/agent-runs/999/intervene", json={"action": "pause"})
+    assert response.status_code == 404
+
+
+def test_get_run_events(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+    monkeypatch.setattr(handler, "get_run", lambda run_id, user_id: {"id": run_id})
+    monkeypatch.setattr(
+        handler,
+        "list_run_events",
+        lambda run_id, user_id, limit=100: [{"id": 1, "event_type": "pause", "created": None}],
+    )
+
+    response = client.get("/api/agent-runs/1/events")
+    assert response.status_code == 200
+    assert len(response.get_json()["events"]) == 1
+
+
+def test_get_run_events_missing_run_returns_404(
+    client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _authenticate(monkeypatch, app_module)
+    import api_endpoints.agent_runs.handler as handler
+
+    monkeypatch.setattr(handler, "user_id_for_email", lambda email: 7)
+    monkeypatch.setattr(handler, "get_run", lambda run_id, user_id: None)
+
+    response = client.get("/api/agent-runs/1/events")
+    assert response.status_code == 404


### PR DESCRIPTION
Addresses #140

## Summary

This PR lays the backend foundation for the operator console epic. It implements one well-scoped slice: a persisted data model for autonomous "runs" plus a REST API for listing/inspecting them and applying operator interventions, with a full audit trail.

### What's included

- **`backend/database/schema.sql`** and **`backend/alembic/versions/0003_agent_runs.py`**: new `agent_runs` table (status, current step, blocker, cost, timestamps, summary) and `agent_run_events` table (audit trail of every intervention).
- **`backend/database/agent_runs.py`**: data-access module with `create_run`, `get_run`, `list_runs`, `update_run_progress`, `increment_run_cost`, and `apply_intervention`. The latter enforces an explicit status state machine (`queued -> running -> (paused) -> running -> (completed | failed | canceled)`) so invalid operator actions raise a clear `ValueError` instead of corrupting state, and every intervention writes a row to `agent_run_events` — directly satisfying the issue's "intervention events are persisted and visible in the audit trail" acceptance criterion.
- **`backend/api_endpoints/agent_runs/handler.py`** + 5 new Flask routes in `backend/app.py`:
  - `POST /api/agent-runs` — queue a new run
  - `GET /api/agent-runs` — list runs (filterable by status)
  - `GET /api/agent-runs/<id>` — fetch a single run
  - `GET /api/agent-runs/<id>/events` — fetch its audit trail
  - `POST /api/agent-runs/<id>/intervene` — pause / resume / cancel / retry / message
- **`backend/tests/test_agent_runs.py`** and **`backend/tests/test_agent_runs_routes.py`**: unit tests for the status machine/data layer and route-level tests for auth, validation, and error paths. All 33 new tests pass; the full backend suite (239 tests) passes with no regressions.

### Out of scope / left for follow-up

- The React/frontend operator console UI itself (project list, live run view, historical run explorer, daily/overnight summary screens).
- Wiring the actual agent execution loop (`agents/autonomous_agent.py`) to create/update `agent_runs` rows as it executes — this PR ships the persistence + control layer, not yet invoked by the agent loop.
- Real-time push/streaming of run status to a console (e.g. SSE/websockets).
- True "retry from checkpoint" semantics — `retry` currently resets status to `queued`; there is no checkpoint/resume-execution-state mechanism yet.
- Overnight/daily summary generation logic.

## Test plan

- [x] `pytest tests/test_agent_runs.py tests/test_agent_runs_routes.py -v` — 33/33 passed
- [x] `pytest tests/ -q` — 239/239 passed, no regressions
- [x] `ruff check` on new files — clean (pre-existing warnings in touched `app.py`/migration-template style left untouched, consistent with rest of codebase)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDp718wense5Kj6ZS2x68P)_