### PR TITLE
Add runtime sandbox controls for dynamic tool execution

### DIFF
--- a/backend/agents/autonomous_agent.py
+++ b/backend/agents/autonomous_agent.py
@@ -16,6 +16,17 @@ to create a new tool at runtime. The tool is validated (AST-based safety check),
 compiled, and added to the session registry. On the next iteration it appears as a
 first-class tool that the LLM can call with a proper schema.
 
+Runtime sandbox (agents/sandbox.py)
+------------------------------------
+AST validation alone only catches statically-detectable misuse; it cannot stop a
+generated tool from looping forever or calling out to an arbitrary host. Every
+dynamic tool invocation therefore runs through `agents.sandbox.run_with_limits`,
+which enforces a wall-clock execution timeout and per-session call/concurrency
+quotas, and network access from dynamic tools goes through
+`agents.sandbox.RestrictedRequests`, which enforces a host allowlist policy
+(dev vs production enforcement modes via `SANDBOX_ENFORCEMENT_MODE`). Violations
+raise `SandboxViolation` and are recorded for audit via `record_violation`.
+
 Built-in tools: retrieve_documents, retrieve_documents_multi, list_documents,
                get_chat_history, run_python, search_web, fetch_url, create_note,
                think, send_email, create_calendar_invite, extract_structured_data,
@@ -50,6 +61,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Generator, Optional
 
 from agents.config import AgentConfig
+from agents.sandbox import RestrictedRequests, SandboxViolation, run_with_limits
 from api_endpoints.financeGPT.chatbot_endpoints import (
     add_message_to_db,
     add_sources_to_db,
@@ -1064,11 +1076,13 @@ def _execute_tool(
         elif name == "call_webhook":
             return _tool_call_webhook(inputs), docs, charts
         elif name == "register_tool":
-            return _tool_register_tool(inputs, session_registry), docs, charts
+            return _tool_register_tool(inputs, session_registry, str(chat_id)), docs, charts
         elif name in session_registry["executors"]:
-            return _tool_run_dynamic(name, inputs, session_registry), docs, charts
+            return _tool_run_dynamic(name, inputs, session_registry, str(chat_id)), docs, charts
         else:
             return f"Unknown tool: '{name}'. If you need this capability, use register_tool to create it.", docs, charts
+    except SandboxViolation as exc:
+        return f"Tool blocked by sandbox ({name}): [{exc.reason}] {exc}", docs, charts
     except Exception as exc:
         return f"Tool error ({name}): {exc}\n{traceback.format_exc()[:400]}", docs, charts
 
@@ -1356,7 +1370,7 @@ def _validate_tool_code(code: str) -> Optional[str]:
     return None  # passed
 
 
-def _tool_register_tool(inputs: dict, session_registry: dict) -> str:
+def _tool_register_tool(inputs: dict, session_registry: dict, session_id: str = "") -> str:
     """Validate, compile, and register a new dynamic tool for this session."""
     name = inputs.get("name", "").strip()
     description = inputs.get("description", "").strip()
@@ -1386,10 +1400,10 @@ def _tool_register_tool(inputs: dict, session_registry: dict) -> str:
     import itertools
     import urllib.parse
 
-    try:
-        import requests as _requests
-    except ImportError:
-        _requests = None  # type: ignore[assignment]
+    # Network access for dynamic tools is routed through RestrictedRequests, which
+    # enforces the sandbox's egress allowlist/policy on every call (see
+    # agents/sandbox.py). This replaces direct exposure of the `requests` module.
+    _requests = RestrictedRequests(session_id)
     try:
         import numpy as _np
     except ImportError:
@@ -1460,14 +1474,27 @@ def _tool_register_tool(inputs: dict, session_registry: dict) -> str:
     )
 
 
-def _tool_run_dynamic(name: str, inputs: dict, session_registry: dict) -> str:
-    """Execute a dynamically registered tool."""
+def _tool_run_dynamic(
+    name: str, inputs: dict, session_registry: dict, session_id: str = ""
+) -> str:
+    """Execute a dynamically registered tool under sandbox runtime limits.
+
+    Enforces a hard execution timeout and per-session call/concurrency quotas
+    (see agents/sandbox.py). A tool that loops indefinitely is abandoned at the
+    timeout boundary and reported as a sandbox violation rather than hanging the
+    request; a session that has exhausted its quota is rejected before the tool
+    code ever runs.
+    """
     executor = session_registry["executors"].get(name)
     if not executor:
         return f"Dynamic tool '{name}' not found in session registry."
     try:
-        result = executor(inputs)
+        result = run_with_limits(
+            lambda: executor(inputs), tool_name=name, session_id=session_id
+        )
         return str(result) if result is not None else "(no output)"
+    except SandboxViolation as exc:
+        return f"Dynamic tool '{name}' blocked by sandbox: [{exc.reason}] {exc}"
     except Exception as exc:
         return f"Dynamic tool '{name}' error: {exc}\n{traceback.format_exc()[:300]}"
 

--- a/backend/agents/sandbox.py
+++ b/backend/agents/sandbox.py
@@ -1,0 +1,390 @@
+"""Runtime sandbox controls for dynamically registered (and select built-in) tools.
+
+This module implements the "Runtime Isolation" and "Policy Integration" pieces of
+issue #133 ("Harden the runtime sandbox for built-in and generated tools"):
+
+- Execution timeouts: every dynamic tool call runs in a worker thread with a hard
+  wall-clock deadline. A tool that loops indefinitely is terminated (the worker
+  thread is abandoned and the call fails closed) instead of hanging the request.
+- Per-session/per-workspace execution quotas: each session has a bounded number of
+  dynamic-tool calls and a bounded number of concurrently in-flight calls.
+- Network egress restrictions: dynamically registered tools get a restricted
+  `requests`-like client that only allows hosts on an allowlist (configurable,
+  defaults to deny-all in production-like enforcement mode).
+- Policy/enforcement modes: `SandboxPolicy` supports a stricter "production" mode
+  and a looser "development" mode, selected via the `SANDBOX_ENFORCEMENT_MODE`
+  env var, mirroring the dev/prod split called for in the issue.
+- Auditable violations: every blocked/timed-out/quota-exceeded call raises a
+  `SandboxViolation` with a machine-readable `reason` code and is recorded via
+  `record_violation` for observability, without leaking raw tool source or
+  request bodies.
+
+This is intentionally scoped to the *dynamic tool* execution path
+(`_tool_run_dynamic` / `register_tool` in `autonomous_agent.py`), which is the
+highest-risk surface called out in the issue (LLM-authored code executed via
+`exec`). CPU/memory rlimits, filesystem syscall interception, and full container
+isolation are out of scope for this change (see PR description).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Violations
+# ---------------------------------------------------------------------------
+
+class SandboxViolation(Exception):
+    """Raised when a tool execution is blocked or terminated by the sandbox.
+
+    `reason` is a short, stable, machine-readable code suitable for metrics/audit
+    logs (never includes raw tool source, request bodies, or other sensitive
+    runtime details).
+    """
+
+    def __init__(self, reason: str, message: str):
+        self.reason = reason
+        super().__init__(message)
+
+
+_VIOLATION_LOG: list[dict] = []
+_VIOLATION_LOG_LOCK = threading.Lock()
+_MAX_VIOLATION_LOG = 500
+
+
+def record_violation(
+    *, reason: str, tool_name: str, session_id: str, detail: str = ""
+) -> None:
+    """Record a sandbox violation for observability/audit purposes.
+
+    Deliberately stores only metadata (reason code, tool name, session id, short
+    detail) — never the offending source code, arguments, or response bodies.
+    """
+    entry = {
+        "ts": time.time(),
+        "reason": reason,
+        "tool_name": tool_name,
+        "session_id": session_id,
+        "detail": detail[:200],
+    }
+    logger.warning(
+        "Sandbox violation: reason=%s tool=%s session=%s detail=%s",
+        reason, tool_name, session_id, entry["detail"],
+    )
+    with _VIOLATION_LOG_LOCK:
+        _VIOLATION_LOG.append(entry)
+        if len(_VIOLATION_LOG) > _MAX_VIOLATION_LOG:
+            del _VIOLATION_LOG[: len(_VIOLATION_LOG) - _MAX_VIOLATION_LOG]
+
+
+def get_recent_violations(limit: int = 50) -> list[dict]:
+    """Return the most recent sandbox violations (for an observability endpoint)."""
+    with _VIOLATION_LOG_LOCK:
+        return list(_VIOLATION_LOG[-limit:])
+
+
+def clear_violations() -> None:
+    """Test helper — clear the in-memory violation log."""
+    with _VIOLATION_LOG_LOCK:
+        _VIOLATION_LOG.clear()
+
+
+# ---------------------------------------------------------------------------
+# Policy — dev vs production enforcement modes
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SandboxPolicy:
+    """Runtime enforcement policy for dynamic tool execution.
+
+    `mode` selects a named preset (development/production); individual fields can
+    still be overridden via env vars for fine-grained control.
+    """
+
+    mode: str
+    timeout_seconds: float
+    max_calls_per_session: int
+    max_concurrent_per_session: int
+    network_allowlist: frozenset
+    allow_network: bool
+
+    @classmethod
+    def from_env(cls) -> SandboxPolicy:
+        mode = os.getenv("SANDBOX_ENFORCEMENT_MODE", "production").strip().lower()
+        if mode not in ("development", "production"):
+            mode = "production"
+
+        if mode == "development":
+            default_timeout = 15.0
+            default_max_calls = 200
+            default_max_concurrent = 8
+            default_allow_network = True
+        else:
+            default_timeout = 5.0
+            default_max_calls = 50
+            default_max_concurrent = 3
+            default_allow_network = False
+
+        timeout_seconds = float(
+            os.getenv("SANDBOX_TOOL_TIMEOUT_SECONDS", str(default_timeout))
+        )
+        max_calls_per_session = int(
+            os.getenv("SANDBOX_MAX_CALLS_PER_SESSION", str(default_max_calls))
+        )
+        max_concurrent_per_session = int(
+            os.getenv("SANDBOX_MAX_CONCURRENT_PER_SESSION", str(default_max_concurrent))
+        )
+        allow_network = (
+            os.getenv(
+                "SANDBOX_ALLOW_NETWORK", "true" if default_allow_network else "false"
+            )
+            .strip()
+            .lower()
+            == "true"
+        )
+        raw_allowlist = os.getenv("SANDBOX_NETWORK_ALLOWLIST", "")
+        network_allowlist = frozenset(
+            host.strip().lower() for host in raw_allowlist.split(",") if host.strip()
+        )
+
+        return cls(
+            mode=mode,
+            timeout_seconds=timeout_seconds,
+            max_calls_per_session=max_calls_per_session,
+            max_concurrent_per_session=max_concurrent_per_session,
+            network_allowlist=network_allowlist,
+            allow_network=allow_network,
+        )
+
+
+_DEFAULT_POLICY: SandboxPolicy | None = None
+
+
+def get_policy() -> SandboxPolicy:
+    """Return the process-wide sandbox policy, loading it from env on first use."""
+    global _DEFAULT_POLICY
+    if _DEFAULT_POLICY is None:
+        _DEFAULT_POLICY = SandboxPolicy.from_env()
+    return _DEFAULT_POLICY
+
+
+def reset_policy_cache() -> None:
+    """Test helper — force the next get_policy() call to re-read env vars."""
+    global _DEFAULT_POLICY
+    _DEFAULT_POLICY = None
+
+
+def is_host_allowed(url: str, policy: SandboxPolicy | None = None) -> bool:
+    """Check whether a URL's host is permitted under the current network policy."""
+    policy = policy or get_policy()
+    if not policy.allow_network:
+        return False
+    if not policy.network_allowlist:
+        # Network is enabled but no explicit allowlist configured — deny by
+        # default (fail closed) rather than silently allowing every host.
+        return False
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    if not host:
+        return False
+    return host in policy.network_allowlist
+
+
+# ---------------------------------------------------------------------------
+# Per-session execution quotas
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _SessionQuotaState:
+    total_calls: int = 0
+    in_flight: int = 0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+class SessionQuotaTracker:
+    """Tracks dynamic-tool call counts/concurrency per session (or workspace)."""
+
+    def __init__(self) -> None:
+        self._sessions: dict = {}
+        self._global_lock = threading.Lock()
+
+    def _state(self, session_id: str) -> _SessionQuotaState:
+        with self._global_lock:
+            state = self._sessions.get(session_id)
+            if state is None:
+                state = _SessionQuotaState()
+                self._sessions[session_id] = state
+            return state
+
+    def acquire(self, session_id: str, policy: SandboxPolicy) -> None:
+        """Reserve quota for one call. Raises SandboxViolation if exhausted."""
+        state = self._state(session_id)
+        with state.lock:
+            if state.total_calls >= policy.max_calls_per_session:
+                raise SandboxViolation(
+                    "quota_exceeded",
+                    f"Session has exceeded its dynamic tool call quota "
+                    f"({policy.max_calls_per_session} calls).",
+                )
+            if state.in_flight >= policy.max_concurrent_per_session:
+                raise SandboxViolation(
+                    "concurrency_exceeded",
+                    f"Session has exceeded its concurrent dynamic tool call limit "
+                    f"({policy.max_concurrent_per_session}).",
+                )
+            state.total_calls += 1
+            state.in_flight += 1
+
+    def release(self, session_id: str) -> None:
+        state = self._state(session_id)
+        with state.lock:
+            state.in_flight = max(0, state.in_flight - 1)
+
+    def reset(self, session_id: str) -> None:
+        with self._global_lock:
+            self._sessions.pop(session_id, None)
+
+
+_QUOTA_TRACKER = SessionQuotaTracker()
+
+
+def get_quota_tracker() -> SessionQuotaTracker:
+    return _QUOTA_TRACKER
+
+
+# ---------------------------------------------------------------------------
+# Timeout-enforced execution
+# ---------------------------------------------------------------------------
+
+def run_with_limits(
+    fn: Callable[[], Any],
+    *,
+    tool_name: str,
+    session_id: str,
+    policy: SandboxPolicy | None = None,
+) -> Any:
+    """Run `fn` under sandbox runtime limits (timeout + per-session quota).
+
+    `fn` runs in a dedicated daemon thread so that a runaway/infinite-looping
+    tool cannot block process shutdown — the calling thread waits at most
+    `policy.timeout_seconds` and then treats the call as terminated, regardless
+    of whether the underlying Python thread (which cannot be forcibly killed)
+    has actually returned. This bounds the *caller's* wait time even though,
+    like most in-process Python sandboxes, it cannot reclaim CPU from a thread
+    that ignores cooperative cancellation (see PR description for the
+    process-isolation follow-up this implies).
+
+    Raises SandboxViolation (fail closed) on timeout or quota exhaustion. Any
+    exception raised by `fn` itself propagates unchanged.
+    """
+    policy = policy or get_policy()
+
+    try:
+        get_quota_tracker().acquire(session_id, policy)
+    except SandboxViolation as exc:
+        record_violation(
+            reason=exc.reason, tool_name=tool_name, session_id=session_id,
+            detail=str(exc),
+        )
+        raise
+
+    result_box: dict = {}
+
+    def _target() -> None:
+        try:
+            result_box["value"] = fn()
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the caller's thread
+            result_box["error"] = exc
+
+    worker = threading.Thread(
+        target=_target, name=f"tool-sandbox-{tool_name}", daemon=True
+    )
+    worker.start()
+    worker.join(timeout=policy.timeout_seconds)
+
+    try:
+        if worker.is_alive():
+            record_violation(
+                reason="timeout",
+                tool_name=tool_name,
+                session_id=session_id,
+                detail=f"exceeded {policy.timeout_seconds}s limit",
+            )
+            raise SandboxViolation(
+                "timeout",
+                f"Tool '{tool_name}' exceeded its {policy.timeout_seconds}s "
+                f"execution time limit and was terminated.",
+            )
+        if "error" in result_box:
+            raise result_box["error"]
+        return result_box.get("value")
+    finally:
+        get_quota_tracker().release(session_id)
+
+
+# ---------------------------------------------------------------------------
+# Restricted network client for dynamic tools
+# ---------------------------------------------------------------------------
+
+class RestrictedRequests:
+    """Drop-in stand-in for the `requests` module exposed to dynamic tool code.
+
+    Delegates to the real `requests` library but enforces the sandbox's network
+    egress policy (allowlist) on every call. Tools that need network access in
+    development mode work normally against allowlisted hosts; in production mode
+    (or with no allowlist configured) all network calls fail closed.
+    """
+
+    def __init__(self, session_id: str, policy: SandboxPolicy | None = None):
+        self._session_id = session_id
+        self._policy = policy or get_policy()
+
+    def _check(self, url: str, method: str) -> None:
+        if not is_host_allowed(url, self._policy):
+            record_violation(
+                reason="network_blocked",
+                tool_name="<dynamic_tool>",
+                session_id=self._session_id,
+                detail=f"{method} {urlparse(url).hostname or url}",
+            )
+            raise SandboxViolation(
+                "network_blocked",
+                f"Network access to '{urlparse(url).hostname or url}' is not "
+                f"permitted by the current sandbox policy.",
+            )
+
+    def get(self, url: str, *args: Any, **kwargs: Any) -> Any:
+        import requests as _requests
+
+        self._check(url, "GET")
+        return _requests.get(url, *args, **kwargs)
+
+    def post(self, url: str, *args: Any, **kwargs: Any) -> Any:
+        import requests as _requests
+
+        self._check(url, "POST")
+        return _requests.post(url, *args, **kwargs)
+
+    def put(self, url: str, *args: Any, **kwargs: Any) -> Any:
+        import requests as _requests
+
+        self._check(url, "PUT")
+        return _requests.put(url, *args, **kwargs)
+
+    def delete(self, url: str, *args: Any, **kwargs: Any) -> Any:
+        import requests as _requests
+
+        self._check(url, "DELETE")
+        return _requests.delete(url, *args, **kwargs)

--- a/backend/tests/test_agent_sandbox.py
+++ b/backend/tests/test_agent_sandbox.py
@@ -1,0 +1,240 @@
+"""Tests for backend/agents/sandbox.py — runtime isolation controls for
+dynamically registered (and select built-in) tool execution.
+
+Covers representative violation cases (timeout, quota exhaustion, concurrency
+limit, network egress block) and representative safe/allowed cases, per the
+acceptance criteria of issue #133.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from agents import sandbox
+
+
+@pytest.fixture(autouse=True)
+def _reset_sandbox_state():
+    """Each test gets a fresh policy cache, quota tracker, and violation log."""
+    sandbox.reset_policy_cache()
+    sandbox.clear_violations()
+    yield
+    sandbox.reset_policy_cache()
+    sandbox.clear_violations()
+
+
+def _policy(**overrides):
+    base = dict(
+        mode="production",
+        timeout_seconds=0.2,
+        max_calls_per_session=3,
+        max_concurrent_per_session=2,
+        network_allowlist=frozenset(),
+        allow_network=False,
+    )
+    base.update(overrides)
+    return sandbox.SandboxPolicy(**base)
+
+
+# ---------------------------------------------------------------------------
+# Policy construction from env
+# ---------------------------------------------------------------------------
+
+class TestPolicyFromEnv:
+    def test_production_is_default_mode(self, monkeypatch):
+        monkeypatch.delenv("SANDBOX_ENFORCEMENT_MODE", raising=False)
+        policy = sandbox.SandboxPolicy.from_env()
+        assert policy.mode == "production"
+        assert policy.allow_network is False
+
+    def test_development_mode_relaxes_limits(self, monkeypatch):
+        monkeypatch.setenv("SANDBOX_ENFORCEMENT_MODE", "development")
+        policy = sandbox.SandboxPolicy.from_env()
+        assert policy.mode == "development"
+        assert policy.timeout_seconds > _policy().timeout_seconds or policy.timeout_seconds == 15.0
+        assert policy.max_calls_per_session > 3
+
+    def test_unknown_mode_falls_back_to_production(self, monkeypatch):
+        monkeypatch.setenv("SANDBOX_ENFORCEMENT_MODE", "yolo")
+        policy = sandbox.SandboxPolicy.from_env()
+        assert policy.mode == "production"
+
+    def test_explicit_overrides_win(self, monkeypatch):
+        monkeypatch.setenv("SANDBOX_ENFORCEMENT_MODE", "production")
+        monkeypatch.setenv("SANDBOX_TOOL_TIMEOUT_SECONDS", "1.5")
+        monkeypatch.setenv("SANDBOX_MAX_CALLS_PER_SESSION", "7")
+        policy = sandbox.SandboxPolicy.from_env()
+        assert policy.timeout_seconds == 1.5
+        assert policy.max_calls_per_session == 7
+
+
+# ---------------------------------------------------------------------------
+# Execution timeout — "generated tool loops indefinitely" scenario
+# ---------------------------------------------------------------------------
+
+class TestRunWithLimitsTimeout:
+    def test_safe_fast_call_succeeds(self):
+        policy = _policy()
+        result = sandbox.run_with_limits(
+            lambda: 6 * 7, tool_name="fast_tool", session_id="s1", policy=policy
+        )
+        assert result == 42
+
+    def test_runaway_call_is_terminated_and_recorded(self):
+        policy = _policy(timeout_seconds=0.1)
+
+        def infinite_loop():
+            while True:
+                time.sleep(0.01)
+
+        with pytest.raises(sandbox.SandboxViolation) as exc_info:
+            sandbox.run_with_limits(
+                infinite_loop, tool_name="runaway_tool", session_id="s1", policy=policy
+            )
+        assert exc_info.value.reason == "timeout"
+
+        violations = sandbox.get_recent_violations()
+        assert any(
+            v["reason"] == "timeout" and v["tool_name"] == "runaway_tool"
+            for v in violations
+        )
+
+    def test_tool_exception_propagates_unchanged(self):
+        policy = _policy()
+
+        def boom():
+            raise ValueError("dynamic tool bug")
+
+        with pytest.raises(ValueError, match="dynamic tool bug"):
+            sandbox.run_with_limits(boom, tool_name="buggy_tool", session_id="s1", policy=policy)
+
+    def test_quota_released_after_timeout(self):
+        """A timed-out call must still release its concurrency slot."""
+        policy = _policy(timeout_seconds=0.1, max_concurrent_per_session=1)
+
+        def infinite_loop():
+            while True:
+                time.sleep(0.01)
+
+        with pytest.raises(sandbox.SandboxViolation):
+            sandbox.run_with_limits(
+                infinite_loop, tool_name="runaway", session_id="s-release", policy=policy
+            )
+
+        # Slot should be free again for a subsequent fast call.
+        result = sandbox.run_with_limits(
+            lambda: "ok", tool_name="fast", session_id="s-release", policy=policy
+        )
+        assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Per-session execution quotas
+# ---------------------------------------------------------------------------
+
+class TestSessionQuotas:
+    def test_quota_exhaustion_blocks_further_calls(self):
+        policy = _policy(max_calls_per_session=2, max_concurrent_per_session=5)
+        session_id = "quota-session"
+
+        sandbox.run_with_limits(lambda: 1, tool_name="t", session_id=session_id, policy=policy)
+        sandbox.run_with_limits(lambda: 2, tool_name="t", session_id=session_id, policy=policy)
+
+        with pytest.raises(sandbox.SandboxViolation) as exc_info:
+            sandbox.run_with_limits(lambda: 3, tool_name="t", session_id=session_id, policy=policy)
+        assert exc_info.value.reason == "quota_exceeded"
+
+    def test_quota_is_isolated_per_session(self):
+        policy = _policy(max_calls_per_session=1, max_concurrent_per_session=5)
+
+        sandbox.run_with_limits(lambda: 1, tool_name="t", session_id="session-a", policy=policy)
+        # A different session should not be affected by session-a's quota.
+        result = sandbox.run_with_limits(
+            lambda: 2, tool_name="t", session_id="session-b", policy=policy
+        )
+        assert result == 2
+
+    def test_concurrency_limit_blocks_overlapping_calls(self):
+        tracker = sandbox.SessionQuotaTracker()
+        policy = _policy(max_calls_per_session=10, max_concurrent_per_session=1)
+
+        tracker.acquire("c1", policy)
+        with pytest.raises(sandbox.SandboxViolation) as exc_info:
+            tracker.acquire("c1", policy)
+        assert exc_info.value.reason == "concurrency_exceeded"
+
+        tracker.release("c1")
+        # Now a slot should be free again.
+        tracker.acquire("c1", policy)
+
+
+# ---------------------------------------------------------------------------
+# Network egress restrictions
+# ---------------------------------------------------------------------------
+
+class TestNetworkPolicy:
+    def test_network_blocked_when_disabled(self):
+        policy = _policy(allow_network=False)
+        assert sandbox.is_host_allowed("https://api.example.com/data", policy) is False
+
+    def test_network_blocked_with_no_allowlist_even_if_enabled(self):
+        policy = _policy(allow_network=True, network_allowlist=frozenset())
+        assert sandbox.is_host_allowed("https://api.example.com/data", policy) is False
+
+    def test_allowlisted_host_is_permitted(self):
+        policy = _policy(
+            allow_network=True, network_allowlist=frozenset({"api.example.com"})
+        )
+        assert sandbox.is_host_allowed("https://api.example.com/data", policy) is True
+
+    def test_non_allowlisted_host_is_blocked(self):
+        policy = _policy(
+            allow_network=True, network_allowlist=frozenset({"api.example.com"})
+        )
+        assert sandbox.is_host_allowed("https://evil.example.org/exfil", policy) is False
+
+    def test_restricted_requests_blocks_disallowed_host(self):
+        policy = _policy(allow_network=False)
+        client = sandbox.RestrictedRequests("session-net", policy=policy)
+        with pytest.raises(sandbox.SandboxViolation) as exc_info:
+            client.get("https://evil.example.org/exfil")
+        assert exc_info.value.reason == "network_blocked"
+        violations = sandbox.get_recent_violations()
+        assert any(v["reason"] == "network_blocked" for v in violations)
+
+    def test_restricted_requests_allows_allowlisted_host(self, monkeypatch):
+        policy = _policy(allow_network=True, network_allowlist=frozenset({"api.example.com"}))
+        client = sandbox.RestrictedRequests("session-net-ok", policy=policy)
+
+        calls = {}
+
+        def fake_get(url, *args, **kwargs):
+            calls["url"] = url
+            return "fake-response"
+
+        monkeypatch.setattr("requests.get", fake_get)
+        result = client.get("https://api.example.com/data")
+        assert result == "fake-response"
+        assert calls["url"] == "https://api.example.com/data"
+
+
+# ---------------------------------------------------------------------------
+# Violation observability
+# ---------------------------------------------------------------------------
+
+class TestViolationLog:
+    def test_record_violation_does_not_leak_raw_detail_beyond_200_chars(self):
+        sandbox.record_violation(
+            reason="timeout",
+            tool_name="t",
+            session_id="s",
+            detail="x" * 1000,
+        )
+        entry = sandbox.get_recent_violations()[-1]
+        assert len(entry["detail"]) == 200
+
+    def test_clear_violations_empties_log(self):
+        sandbox.record_violation(reason="timeout", tool_name="t", session_id="s")
+        assert sandbox.get_recent_violations()
+        sandbox.clear_violations()
+        assert sandbox.get_recent_violations() == []


### PR DESCRIPTION
Addresses #133

## What this PR implements

Issue #133 is a large epic asking for hardened runtime sandboxing across all tool execution (built-in and dynamically generated). This PR implements a scoped, working subset focused on the highest-risk surface called out in the issue: the **dynamic tool registration/execution path** in `backend/agents/autonomous_agent.py`, where the LLM-authored `register_tool` writes Python code that gets `exec`'d and later invoked via `_tool_run_dynamic`.

Previously this path only had AST-based static validation (blocked imports/builtins/dunder access) with **no runtime enforcement at all** — a generated tool with an infinite loop would hang the request indefinitely, there was no cap on how many dynamic tools a session could invoke, and the sandboxed `requests` module had unrestricted network access to any host.

New module `backend/agents/sandbox.py` adds:

- **Execution timeouts** — `run_with_limits()` runs each dynamic tool call in a worker thread with a hard wall-clock deadline (configurable, default 5s in production / 15s in development). A call that doesn't return in time is treated as terminated and reported as a sandbox violation rather than blocking the request forever (addresses the "generated tool loops indefinitely" example scenario from the issue).
- **Per-session execution quotas** — `SessionQuotaTracker` bounds both total dynamic-tool calls and concurrently in-flight calls per chat session (`chat_id` is used as the session key).
- **Network egress restrictions** — `RestrictedRequests` replaces the raw `requests` module exposed to dynamic tool code. It checks every `GET`/`POST`/`PUT`/`DELETE` call against a configurable host allowlist and fails closed (addresses the "non-allowlisted network destination" example scenario).
- **Policy / enforcement modes** — `SandboxPolicy` has `development` and `production` presets (selected via `SANDBOX_ENFORCEMENT_MODE`), with production defaulting to network disabled and stricter timeout/quota limits, plus per-field env var overrides (`SANDBOX_TOOL_TIMEOUT_SECONDS`, `SANDBOX_MAX_CALLS_PER_SESSION`, `SANDBOX_MAX_CONCURRENT_PER_SESSION`, `SANDBOX_ALLOW_NETWORK`, `SANDBOX_NETWORK_ALLOWLIST`).
- **Auditable violations** — every blocked/timed-out/quota-exceeded call raises `SandboxViolation` with a stable machine-readable `reason` code (`timeout`, `quota_exceeded`, `concurrency_exceeded`, `network_blocked`) and is recorded via `record_violation()`, which stores only metadata (reason, tool name, session id, truncated detail) — never raw tool source, arguments, or response bodies — exposed via `get_recent_violations()` for observability.

Wiring into `autonomous_agent.py`:
- `_tool_run_dynamic` now executes through `run_with_limits`.
- `_tool_register_tool` now hands dynamic tool code a `RestrictedRequests` instance instead of the raw `requests` module.
- `_execute_tool` catches `SandboxViolation` and returns a clear, non-leaking error string to the LLM/UI instead of letting the exception escape.

Tests added in `backend/tests/test_agent_sandbox.py` (19 cases) cover both violation and safe/allowed paths per the issue's acceptance criteria: policy construction from env (dev vs prod presets, overrides, fallback for unknown modes), timeout enforcement (safe fast call, runaway call terminated + recorded, quota released after timeout, underlying exceptions still propagate), per-session quota exhaustion and isolation, concurrency limits, network allowlist enforcement (blocked/allowed hosts, `RestrictedRequests` GET behavior), and violation log behavior (truncation, clearing).

All new code passes `ruff check` and the new test file passes standalone (`pytest backend/tests/test_agent_sandbox.py`, 19/19). Confirmed the pre-existing test collection errors for `test_finance_gpt_service.py`, `test_language_chat.py`, and `test_models.py` (missing `PyPDF2`/`sqlalchemy` in this environment) are present on `main` as well and unrelated to this change.

## Out of scope / left for follow-up

This PR intentionally does not attempt the full epic. Not implemented here:

- **CPU/memory rlimits** — Python's `threading` model cannot forcibly kill a thread or cap its CPU/memory; true resource isolation needs subprocess- or container-based execution (e.g. running dynamic tools in a separate restricted subprocess, similar to how the existing `run_python` built-in tool already uses `subprocess.run(..., timeout=30)`).
- **Filesystem access constraints** — no sandboxed filesystem (chroot/restricted FS view) is added; the AST validator already blocks `open`, but a determined dynamic tool could still abuse other ambient state.
- **Package/import allowlists beyond the existing AST check** — the pre-existing `_validate_tool_code` blocked-module list is unchanged; this PR doesn't add a separate configurable allowlist mechanism for imports.
- **Per-workspace quotas** — quotas here are scoped to `chat_id` (session), not workspace; multi-tenant workspace-level aggregation is not implemented.
- **Applying sandbox controls to built-in tools** — `run_python`, `fetch_url`, `search_web`, `call_webhook`, etc. are unchanged; this PR only covers the dynamically-registered-tool path, which is the highest-risk surface (LLM-authored code via `exec`).
- **Policy/approval system integration** — the issue asks for connecting sandbox settings to "the broader policy/approval system"; no such system currently exists in this codebase, so this PR only adds the `SandboxPolicy` enforcement-mode primitive that a future approval system could plug into.
- **Observability endpoint** — `get_recent_violations()` exists as a queryable in-process function but no HTTP endpoint exposes it yet.

## Test plan
- [x] `pytest backend/tests/test_agent_sandbox.py -v` — 19/19 passing
- [x] `ruff check backend/agents/sandbox.py backend/tests/test_agent_sandbox.py` — clean
- [x] Verified `backend/agents/autonomous_agent.py` still parses and the diff is scoped to only the intended wiring changes
- [x] Confirmed pre-existing test collection failures in unrelated test files exist on `main` too (missing optional deps in this sandbox, not caused by this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDp718wense5Kj6ZS2x68P)_