### PR TITLE
feat(rsi): wire implicit follow-up feedback into chat paths

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -70,6 +70,7 @@ from database.db import (
     update_chat_name as update_chat_name_in_db,
     update_user_profile,
 )
+from database.feedback_signals import record_followup_if_any
 from database.db_pool import get_db_connection
 from database.db_auth import (
     api_key_access_invalid,
@@ -953,6 +954,24 @@ def _parse_message_request(req):
     return message_text, chat_id, model_type, model_key, is_guest, media_attachments
 
 
+def _record_rsi_followup_feedback(user_email, chat_id, chat_type=0):
+    """Record an implicit follow-up signal before the new user turn is saved."""
+    try:
+        chat_id_int = int(chat_id)
+    except (TypeError, ValueError):
+        return False
+    if chat_id_int <= 0:
+        return False
+
+    if isinstance(chat_type, str):
+        clean_chat_type = chat_type.strip()
+        chat_type_value = int(clean_chat_type) if clean_chat_type.isdigit() else clean_chat_type or 0
+    else:
+        chat_type_value = chat_type or 0
+
+    return record_followup_if_any(user_email, chat_id_int, chat_type_value)
+
+
 @app.route('/process-message-pdf', methods=['POST'])
 def process_message_pdf():  # pragma: no cover
 
@@ -968,6 +987,7 @@ def process_message_pdf():  # pragma: no cover
         except Exception as e:
             print(f"Authentication error in process_message_pdf: {type(e).__name__}")
             return jsonify({"error": "Authentication error"}), 401
+        _record_rsi_followup_feedback(user_email, chat_id, 0)
 
     # Check if agents are enabled
     if AgentConfig.is_agent_enabled():
@@ -1574,6 +1594,7 @@ def public_ingest_pdf():  # pragma: no cover
     model_key = request.json.get('model_key')
 
     model_type, task_type, _ = get_chat_info(chat_id)
+    _record_rsi_followup_feedback(user_email, chat_id, task_type)
 
     if AgentConfig.is_agent_enabled():
         try:
@@ -2035,6 +2056,7 @@ def v1_chat_completions():  # pragma: no cover
             user_email = USER_EMAIL_API
             ensure_SDK_user_exists(user_email)
 
+            _record_rsi_followup_feedback(user_email, chat_id, 0)
             add_message_to_db(user_message, chat_id, 1)
             sources = get_relevant_chunks(2, user_message, chat_id, user_email, include_metadata=True)
             sources_str = sources_to_prompt_context(sources)
@@ -2245,6 +2267,7 @@ def v1_question_answer():  # pragma: no cover
     user_email = USER_EMAIL_API
     ensure_SDK_user_exists(user_email)
 
+    _record_rsi_followup_feedback(user_email, chat_id, 0)
     add_message_to_db(question, chat_id, 1)
     sources = get_relevant_chunks(2, question, chat_id, user_email, include_metadata=True)
     sources_str = sources_to_prompt_context(sources)

--- a/backend/database/feedback_signals.py
+++ b/backend/database/feedback_signals.py
@@ -9,11 +9,9 @@ soft-negative training signal for the RSI loop.
 Same constraints as slice 1: opt-in (`ENABLE_RSI_FEEDBACK`) and best-effort
 (detection/logging must never break a chat).
 
-Wiring (slice 2 integration, intentionally NOT done here): call
-`record_followup_if_any(user_email, chat_id, chat_type)` at the start of handling
-a new user turn, before the new message is persisted. Kept out of the live
-multi-agent path in this PR so the detection logic can land tested and reviewed
-first; the call site is a one-liner (see PR description).
+Wiring: call `record_followup_if_any(user_email, chat_id, chat_type)` at the
+start of handling a new user turn, before the new message is persisted. That
+scores the previous assistant answer instead of the new user question.
 """
 from __future__ import annotations
 
@@ -83,7 +81,7 @@ def detect_followup_signal(
 def record_followup_if_any(
     user_email: str,
     chat_id: int,
-    chat_type: int,
+    chat_type: int | str,
     now: datetime | None = None,
 ) -> bool:
     """Best-effort: detect a rapid follow-up against this chat's history and log it.

--- a/backend/database/feedback_signals.py
+++ b/backend/database/feedback_signals.py
@@ -1,0 +1,109 @@
+"""Implicit RSI feedback-signal detection for document Q&A — issue #220 (slice 2).
+
+Slice 1 (`database/qa_feedback.py`) added the `qa_feedback` table and the
+`log_qa_feedback()` writer. This slice derives an **implicit** signal from chat
+history with no UI change: a *rapid follow-up*. If the user asks again within a
+short window of the previous answer, that answer was probably incomplete — a
+soft-negative training signal for the RSI loop.
+
+Same constraints as slice 1: opt-in (`ENABLE_RSI_FEEDBACK`) and best-effort
+(detection/logging must never break a chat).
+
+Wiring (slice 2 integration, intentionally NOT done here): call
+`record_followup_if_any(user_email, chat_id, chat_type)` at the start of handling
+a new user turn, before the new message is persisted. Kept out of the live
+multi-agent path in this PR so the detection logic can land tested and reviewed
+first; the call site is a one-liner (see PR description).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from database.qa_feedback import log_qa_feedback, rsi_feedback_enabled
+
+# A follow-up within this many seconds of the previous answer is treated as an
+# implicit "that answer didn't fully land" signal.
+FOLLOWUP_WINDOW_SECS = 30.0
+
+# `retrieve_messages` is bound lazily from `database.db` on first use. This keeps
+# the module importable (and `detect_followup_signal` unit-testable) without
+# pulling the heavy DB module, and gives tests a clean seam to patch.
+_retrieve_messages: Any = None
+
+
+def _is_user(message: dict[str, Any]) -> bool:
+    return bool(message.get("sent_from_user"))
+
+
+def _age_seconds(created: Any, now: datetime) -> float | None:
+    """Seconds between ``created`` and ``now``; None if ``created`` isn't a datetime."""
+    if isinstance(created, datetime):
+        return (now - created).total_seconds()
+    return None  # unknown timestamp type → skip (best-effort)
+
+
+def detect_followup_signal(
+    messages: list[dict[str, Any]],
+    now: datetime,
+    window_secs: float = FOLLOWUP_WINDOW_SECS,
+) -> dict[str, Any] | None:
+    """Return a qa_feedback record for the most recent answer if the user is
+    following up within ``window_secs`` of it, else ``None``.
+
+    ``messages`` is chronological (oldest → newest), as returned by
+    ``database.db.retrieve_messages`` (dicts with ``created``, ``id``,
+    ``message_text``, ``sent_from_user``, ``relevant_chunks``).
+    """
+    if not messages:
+        return None
+    last = messages[-1]
+    if _is_user(last):
+        return None  # last turn is the user's; no answer to score yet
+    age = _age_seconds(last.get("created"), now)
+    if age is None or age < 0 or age > window_secs:
+        return None
+
+    question = ""
+    for prev in reversed(messages[:-1]):
+        if _is_user(prev):
+            question = str(prev.get("message_text", ""))
+            break
+
+    return {
+        "message_id": last.get("id"),
+        "question": question,
+        "answer": str(last.get("message_text", "")),
+        "retrieved_chunks": last.get("relevant_chunks"),
+        "feedback_signal": "followup",
+        "source": "implicit",
+    }
+
+
+def record_followup_if_any(
+    user_email: str,
+    chat_id: int,
+    chat_type: int,
+    now: datetime | None = None,
+) -> bool:
+    """Best-effort: detect a rapid follow-up against this chat's history and log it.
+
+    No-op (returns False) when RSI feedback is disabled. Never raises — a feedback
+    side-channel must not break the chat response.
+    """
+    global _retrieve_messages
+    if not rsi_feedback_enabled():
+        return False
+    try:
+        if _retrieve_messages is None:
+            from database.db import retrieve_messages
+
+            _retrieve_messages = retrieve_messages
+        messages = _retrieve_messages(user_email, chat_id, chat_type) or []
+        record = detect_followup_signal(messages, now or datetime.now())
+        if record is None:
+            return False
+        return log_qa_feedback(chat_id=chat_id, **record)
+    except Exception as exc:  # detection must never break a chat
+        print(f"[rsi] record_followup_if_any failed: {exc}")
+        return False

--- a/backend/database/qa_feedback.py
+++ b/backend/database/qa_feedback.py
@@ -46,7 +46,7 @@ def log_qa_feedback(
     answer: str,
     feedback_signal: str,
     message_id: int | None = None,
-    retrieved_chunks: Sequence[Any] | None = None,
+    retrieved_chunks: str | Sequence[Any] | None = None,
     session_id: str | None = None,
     source: str = "implicit",
 ) -> bool:
@@ -60,7 +60,14 @@ def log_qa_feedback(
     if feedback_signal not in VALID_SIGNALS:
         return False
 
-    chunks_json = json.dumps(list(retrieved_chunks)) if retrieved_chunks else None
+    # retrieved_chunks may be a pre-serialized string (e.g. messages.relevant_chunks
+    # from the DB) or a fresh sequence of chunks — handle both.
+    if retrieved_chunks is None:
+        chunks_json = None
+    elif isinstance(retrieved_chunks, str):
+        chunks_json = retrieved_chunks
+    else:
+        chunks_json = json.dumps(list(retrieved_chunks))
     conn = None
     try:
         conn, cursor = get_db_connection()

--- a/backend/tests/test_feedback_signals.py
+++ b/backend/tests/test_feedback_signals.py
@@ -1,0 +1,122 @@
+"""Tests for database/feedback_signals.py — implicit RSI signals (issue #220, slice 2).
+
+Pure logic + best-effort orchestration; deps (retrieve_messages, log_qa_feedback)
+are monkeypatched, so these run offline under the conftest mysql stub.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from database import feedback_signals as fs
+
+NOW = datetime(2026, 6, 14, 12, 0, 0)
+
+
+def _msg(
+    text: str,
+    is_user: bool,
+    created: Any,
+    mid: int | None = None,
+    chunks: Any = None,
+) -> dict[str, Any]:
+    return {
+        "message_text": text,
+        "sent_from_user": 1 if is_user else 0,
+        "created": created,
+        "id": mid,
+        "relevant_chunks": chunks,
+    }
+
+
+# --- detect_followup_signal ------------------------------------------------ #
+
+def test_detect_followup_within_window() -> None:
+    msgs = [
+        _msg("what is EBITDA?", True, NOW - timedelta(seconds=40)),
+        _msg("EBITDA is ...", False, NOW - timedelta(seconds=5), mid=99, chunks="c1|c2"),
+    ]
+    rec = fs.detect_followup_signal(msgs, NOW)
+    assert rec is not None
+    assert rec["feedback_signal"] == "followup"
+    assert rec["message_id"] == 99
+    assert rec["question"] == "what is EBITDA?"
+    assert rec["answer"] == "EBITDA is ..."
+    assert rec["retrieved_chunks"] == "c1|c2"
+
+
+def test_detect_none_when_answer_too_old() -> None:
+    msgs = [
+        _msg("q", True, NOW - timedelta(seconds=120)),
+        _msg("a", False, NOW - timedelta(seconds=60), mid=1),  # 60s > 30s window
+    ]
+    assert fs.detect_followup_signal(msgs, NOW) is None
+
+
+def test_detect_none_when_last_is_user() -> None:
+    msgs = [
+        _msg("a", False, NOW - timedelta(seconds=5), mid=1),
+        _msg("q2", True, NOW),
+    ]
+    assert fs.detect_followup_signal(msgs, NOW) is None
+
+
+def test_detect_none_empty() -> None:
+    assert fs.detect_followup_signal([], NOW) is None
+
+
+def test_detect_none_non_datetime_created() -> None:
+    msgs = [_msg("q", True, "2026-06-14"), _msg("a", False, "2026-06-14", mid=1)]
+    assert fs.detect_followup_signal(msgs, NOW) is None
+
+
+# --- record_followup_if_any ------------------------------------------------ #
+
+def test_record_disabled_is_noop(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "false")
+
+    def _fail(*a: Any, **k: Any) -> Any:
+        raise AssertionError("must not be called when disabled")
+
+    monkeypatch.setattr(fs, "_retrieve_messages", _fail)
+    monkeypatch.setattr(fs, "log_qa_feedback", _fail)
+    assert fs.record_followup_if_any("u@x", 1, 0) is False
+
+
+def test_record_enabled_logs_followup(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+    msgs = [
+        _msg("q", True, NOW - timedelta(seconds=40)),
+        _msg("a", False, NOW - timedelta(seconds=3), mid=7, chunks="c"),
+    ]
+    monkeypatch.setattr(fs, "_retrieve_messages", lambda *a, **k: msgs)
+    logged: dict[str, Any] = {}
+
+    def _fake_log(**kw: Any) -> bool:
+        logged.update(kw)
+        return True
+
+    monkeypatch.setattr(fs, "log_qa_feedback", _fake_log)
+    assert fs.record_followup_if_any("u@x", 5, 0, now=NOW) is True
+    assert logged["chat_id"] == 5
+    assert logged["feedback_signal"] == "followup"
+    assert logged["message_id"] == 7
+
+
+def test_record_no_followup_returns_false(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+    msgs = [_msg("a", False, NOW - timedelta(seconds=300), mid=1)]  # too old
+    monkeypatch.setattr(fs, "_retrieve_messages", lambda *a, **k: msgs)
+    monkeypatch.setattr(fs, "log_qa_feedback", lambda **k: True)
+    assert fs.record_followup_if_any("u@x", 5, 0, now=NOW) is False
+
+
+def test_record_swallows_exception(monkeypatch: Any) -> None:
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+
+    def _boom(*a: Any, **k: Any) -> Any:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(fs, "_retrieve_messages", _boom)
+    assert fs.record_followup_if_any("u@x", 5, 0) is False

--- a/backend/tests/test_qa_feedback.py
+++ b/backend/tests/test_qa_feedback.py
@@ -70,6 +70,19 @@ def test_enabled_writes_row(monkeypatch: Any) -> None:
     assert params[3] == '["c1", "c2"]'  # retrieved_chunks serialized to JSON
 
 
+def test_pre_serialized_string_chunks_stored_as_is(monkeypatch: Any) -> None:
+    # messages.relevant_chunks comes from the DB as an already-serialized string;
+    # it must be stored verbatim, not split into characters by list().
+    monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
+    conn = _install_fake(monkeypatch)
+    assert qa_feedback.log_qa_feedback(
+        chat_id=1, question="q", answer="a", feedback_signal="followup",
+        retrieved_chunks="chunk-a|chunk-b",
+    ) is True
+    _sql, params = conn.cursor_obj.executed[0]
+    assert params[3] == "chunk-a|chunk-b"
+
+
 def test_invalid_signal_rejected(monkeypatch: Any) -> None:
     monkeypatch.setenv("ENABLE_RSI_FEEDBACK", "true")
     conn = _install_fake(monkeypatch)

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -417,13 +417,14 @@ def test_infer_chat_name_invalid_token(client: Any, app_module: Any, monkeypatch
 
 
 def test_process_message_pdf_guest_fallback_success(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-    rsi_calls: list[tuple[str, int, int]] = []
+    rsi_calls: list[tuple[str, int, int | str]] = []
+
+    def _record(user_email: str, chat_id: int, chat_type: int | str) -> bool:
+        rsi_calls.append((user_email, chat_id, chat_type))
+        return False
+
     monkeypatch.setattr(app_module.AgentConfig, "is_agent_enabled", staticmethod(lambda: False))
-    monkeypatch.setattr(
-        app_module,
-        "record_followup_if_any",
-        lambda user_email, chat_id, chat_type: rsi_calls.append((user_email, chat_id, chat_type)) or False,
-    )
+    monkeypatch.setattr(app_module, "record_followup_if_any", _record)
     response = client.post(
         "/process-message-pdf",
         json={"message": "hello", "chat_id": 0, "model_type": 0, "is_guest": True},
@@ -463,9 +464,9 @@ def test_generate_follow_up_questions_caps_at_three(app_module: Any, monkeypatch
 
 
 def test_record_rsi_followup_feedback_helper(app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[tuple[str, int, int]] = []
+    calls: list[tuple[str, int, int | str]] = []
 
-    def _record(user_email: str, chat_id: int, chat_type: int) -> bool:
+    def _record(user_email: str, chat_id: int, chat_type: int | str) -> bool:
         calls.append((user_email, chat_id, chat_type))
         return True
 
@@ -484,7 +485,11 @@ def test_record_rsi_followup_feedback_helper(app_module: Any, monkeypatch: pytes
 
 def test_process_message_pdf_authenticated_agent_stream(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]) -> None:
     _authenticate(monkeypatch, app_module)
-    rsi_calls: list[tuple[str, int, int]] = []
+    rsi_calls: list[tuple[str, int, int | str]] = []
+
+    def _record(user_email: str, chat_id: int, chat_type: int | str) -> bool:
+        rsi_calls.append((user_email, chat_id, chat_type))
+        return False
 
     class StreamingAgent:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -495,11 +500,7 @@ def test_process_message_pdf_authenticated_agent_stream(client: Any, app_module:
 
     monkeypatch.setattr(app_module.AgentConfig, "is_agent_enabled", staticmethod(lambda: True))
     monkeypatch.setattr(app_module, "AutonomousDocumentAgent", StreamingAgent)
-    monkeypatch.setattr(
-        app_module,
-        "record_followup_if_any",
-        lambda user_email, chat_id, chat_type: rsi_calls.append((user_email, chat_id, chat_type)) or False,
-    )
+    monkeypatch.setattr(app_module, "record_followup_if_any", _record)
     response = client.post(
         "/process-message-pdf",
         json={"message": "hello", "chat_id": 1, "model_type": 0, "is_guest": False},
@@ -606,7 +607,12 @@ def test_public_endpoints_require_valid_api_key(client: Any, app_module: Any, mo
 
 
 def test_public_chat_and_evaluate(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-    rsi_calls: list[tuple[str, int, int]] = []
+    rsi_calls: list[tuple[str, int, int | str]] = []
+
+    def _record(user_email: str, chat_id: int, chat_type: int | str) -> bool:
+        rsi_calls.append((user_email, chat_id, chat_type))
+        return False
+
     monkeypatch.setattr(app_module, "is_api_key_valid", lambda api_key: True)
     monkeypatch.setattr("database.db_auth.api_key_user_has_credits", lambda api_key, min_credits=1: True)
     monkeypatch.setattr("database.db_auth.deduct_credits_from_api_key_user", lambda api_key, credits: True)
@@ -629,11 +635,7 @@ def test_public_chat_and_evaluate(client: Any, app_module: Any, monkeypatch: pyt
     )
     monkeypatch.setattr(app_module, "add_message_to_db", lambda *args, **kwargs: 10)
     monkeypatch.setattr(app_module, "add_sources_to_db", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        app_module,
-        "record_followup_if_any",
-        lambda user_email, chat_id, chat_type: rsi_calls.append((user_email, chat_id, chat_type)) or False,
-    )
+    monkeypatch.setattr(app_module, "record_followup_if_any", _record)
     monkeypatch.setattr(
         app_module,
         "get_message_info",

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -417,7 +417,13 @@ def test_infer_chat_name_invalid_token(client: Any, app_module: Any, monkeypatch
 
 
 def test_process_message_pdf_guest_fallback_success(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    rsi_calls: list[tuple[str, int, int]] = []
     monkeypatch.setattr(app_module.AgentConfig, "is_agent_enabled", staticmethod(lambda: False))
+    monkeypatch.setattr(
+        app_module,
+        "record_followup_if_any",
+        lambda user_email, chat_id, chat_type: rsi_calls.append((user_email, chat_id, chat_type)) or False,
+    )
     response = client.post(
         "/process-message-pdf",
         json={"message": "hello", "chat_id": 0, "model_type": 0, "is_guest": True},
@@ -426,6 +432,7 @@ def test_process_message_pdf_guest_fallback_success(client: Any, app_module: Any
     data = response.get_json()
     assert "guest mode" in data["answer"]
     assert data["suggested_follow_ups"] == []
+    assert rsi_calls == []
 
 
 def test_generate_follow_up_questions_returns_list(app_module: Any) -> None:
@@ -455,8 +462,29 @@ def test_generate_follow_up_questions_caps_at_three(app_module: Any, monkeypatch
     assert len(result) <= 3
 
 
+def test_record_rsi_followup_feedback_helper(app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, int, int]] = []
+
+    def _record(user_email: str, chat_id: int, chat_type: int) -> bool:
+        calls.append((user_email, chat_id, chat_type))
+        return True
+
+    monkeypatch.setattr(app_module, "record_followup_if_any", _record)
+
+    assert app_module._record_rsi_followup_feedback("u@example.com", "bad", 0) is False
+    assert app_module._record_rsi_followup_feedback("u@example.com", 0, 0) is False
+    assert calls == []
+
+    assert app_module._record_rsi_followup_feedback("u@example.com", "9", "2") is True
+    assert calls == [("u@example.com", 9, 2)]
+
+    assert app_module._record_rsi_followup_feedback("u@example.com", "10", "documents") is True
+    assert calls[-1] == ("u@example.com", 10, "documents")
+
+
 def test_process_message_pdf_authenticated_agent_stream(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]) -> None:
     _authenticate(monkeypatch, app_module)
+    rsi_calls: list[tuple[str, int, int]] = []
 
     class StreamingAgent:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -467,6 +495,11 @@ def test_process_message_pdf_authenticated_agent_stream(client: Any, app_module:
 
     monkeypatch.setattr(app_module.AgentConfig, "is_agent_enabled", staticmethod(lambda: True))
     monkeypatch.setattr(app_module, "AutonomousDocumentAgent", StreamingAgent)
+    monkeypatch.setattr(
+        app_module,
+        "record_followup_if_any",
+        lambda user_email, chat_id, chat_type: rsi_calls.append((user_email, chat_id, chat_type)) or False,
+    )
     response = client.post(
         "/process-message-pdf",
         json={"message": "hello", "chat_id": 1, "model_type": 0, "is_guest": False},
@@ -474,6 +507,7 @@ def test_process_message_pdf_authenticated_agent_stream(client: Any, app_module:
     )
     assert response.status_code == 200
     assert "chunk-1" in response.get_data(as_text=True)
+    assert rsi_calls == [("test@example.com", 1, 0)]
 
 
 def test_process_message_pdf_streaming_sets_sse_headers(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]) -> None:
@@ -572,6 +606,7 @@ def test_public_endpoints_require_valid_api_key(client: Any, app_module: Any, mo
 
 
 def test_public_chat_and_evaluate(client: Any, app_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    rsi_calls: list[tuple[str, int, int]] = []
     monkeypatch.setattr(app_module, "is_api_key_valid", lambda api_key: True)
     monkeypatch.setattr("database.db_auth.api_key_user_has_credits", lambda api_key, min_credits=1: True)
     monkeypatch.setattr("database.db_auth.deduct_credits_from_api_key_user", lambda api_key, credits: True)
@@ -594,6 +629,11 @@ def test_public_chat_and_evaluate(client: Any, app_module: Any, monkeypatch: pyt
     )
     monkeypatch.setattr(app_module, "add_message_to_db", lambda *args, **kwargs: 10)
     monkeypatch.setattr(app_module, "add_sources_to_db", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        app_module,
+        "record_followup_if_any",
+        lambda user_email, chat_id, chat_type: rsi_calls.append((user_email, chat_id, chat_type)) or False,
+    )
     monkeypatch.setattr(
         app_module,
         "get_message_info",
@@ -624,6 +664,7 @@ def test_public_chat_and_evaluate(client: Any, app_module: Any, monkeypatch: pyt
             }
         ],
     }
+    assert rsi_calls == [("api@example.com", 9, 0)]
 
     evaluate_response = client.post(
         "/public/evaluate",


### PR DESCRIPTION
## What this is
Slice 2 for #220. This builds on the merged qa_feedback foundation (#223) and replaces the closed/unmerged follow-up signal PR (#225).

## Changes
- Adds `database/feedback_signals.py` for rapid follow-up detection against recent chat history.
- Extends `log_qa_feedback()` so it preserves pre-serialized `messages.relevant_chunks`.
- Wires the best-effort, feature-flagged hook into chat entrypoints before the new user turn is persisted:
  - `/process-message-pdf`
  - `/public/chat`
  - `/v1/chat/completions` when grounded by `chat_id`
  - `/v1/question-answer`
- Keeps collection opt-in via `ENABLE_RSI_FEEDBACK=true`; default behavior is unchanged.

## Safety
- The hook is best-effort and never raises through the chat path.
- Guest chat and invalid/zero chat IDs are skipped.
- Numeric chat types are normalized, while string chat types like `documents` are preserved.

## Testing
- `UV_PROJECT_ENVIRONMENT=/tmp/panacea-rsi-backend-uv-env uv run --no-project --python 3.12 --with-requirements <(grep -v "^mysqlclient" backend/requirements.txt) python -m pytest -o addopts="" backend/tests -q`
  - 217 passed, 18 warnings
- `UV_PROJECT_ENVIRONMENT=/tmp/panacea-rsi-backend-uv-env uv run --no-project --python 3.12 --with-requirements <(grep -v "^mysqlclient" backend/requirements.txt) mypy --explicit-package-bases backend/tests backend/api_endpoints/chat/handler.py backend/api_endpoints/documents/handler.py backend/app_helpers.py`
- `uvx --from ruff==0.15.16 ruff check backend/tests backend/api_endpoints/chat/handler.py backend/api_endpoints/documents/handler.py backend/app_helpers.py`
- `git diff --check`

Note: local full `backend/requirements.txt` install requires native mysqlclient/pkg-config, so the manual test run mirrors backend requirements with only mysqlclient filtered out; tests use the repo mysql stubs.