### PR TITLE
fix: web Docker build fails in monorepo due to missing root workspace…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,8 @@ services:
 
   web:
     build:
-      context: ./packages/web
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: packages/web/Dockerfile
     restart: always
     ports:
       - "3000:3000"

--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -2,15 +2,19 @@ FROM node:20.19.0-slim AS build
 
 WORKDIR /app
 
+# Copy root workspace files first so npm can resolve hoisted dependencies
 COPY package*.json ./
-RUN npm install
+COPY packages/web/package*.json ./packages/web/
 
-COPY . .
-RUN npm run build
+RUN npm install --workspace=packages/web
+
+COPY packages/web ./packages/web
+
+RUN npm run build --workspace=packages/web
 
 FROM nginx:1.27-alpine
 
-COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/packages/web/dist /usr/share/nginx/html
+COPY packages/web/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 3000


### PR DESCRIPTION
The web Dockerfile used packages/web as the build context, so hoisted node_modules (including esbuild) were not available during npm run build.

Fix: set build context to repo root and install via npm workspaces so all hoisted dependencies are resolved correctly.