### PR TITLE
feat(backend): chat/message persistence helpers (foundation for #210/RSI #220)

### DIFF
--- a/packages/backend/database/db.py
+++ b/packages/backend/database/db.py
@@ -40,3 +40,63 @@ def create_user(cnx: Any, email: str, password_hash: str, name: str = "") -> int
     user_id: int = cursor.lastrowid
     cursor.close()
     return user_id
+
+
+# ── Chat / message persistence (foundation for #210 / RSI #220) ──────────────
+
+
+def create_chat(cnx: Any, user_id: int, name: str = "New Chat", mode: str = "chat") -> int:
+    """Create a chat row and return its id."""
+    cursor = cnx.cursor()
+    cursor.execute(
+        "INSERT INTO chats (user_id, name, mode, created_at) VALUES (%s, %s, %s, NOW())",
+        (user_id, name, mode),
+    )
+    chat_id: int = cursor.lastrowid
+    cursor.close()
+    return chat_id
+
+
+def add_message(
+    cnx: Any,
+    chat_id: int,
+    role: str,
+    content: str,
+    model: str | None = None,
+    tokens: int = 0,
+) -> int:
+    """Append a message to a chat and return its id. ``role`` is user/assistant/system."""
+    cursor = cnx.cursor()
+    cursor.execute(
+        "INSERT INTO messages (chat_id, role, content, model, tokens, created_at) "
+        "VALUES (%s, %s, %s, %s, %s, NOW())",
+        (chat_id, role, content, model, tokens),
+    )
+    message_id: int = cursor.lastrowid
+    cursor.close()
+    return message_id
+
+
+def get_messages(cnx: Any, chat_id: int) -> list[dict]:
+    """Return a chat's messages in chronological order (oldest first)."""
+    cursor = cnx.cursor(dictionary=True)
+    cursor.execute(
+        "SELECT id, role, content, model, tokens, created_at "
+        "FROM messages WHERE chat_id = %s ORDER BY id ASC",
+        (chat_id,),
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+    return rows
+
+
+def get_chats(cnx: Any, user_id: int) -> list[dict]:
+    """Return a user's chats, most recent first."""
+    cursor = cnx.cursor(dictionary=True)
+    cursor.execute(
+        "SELECT id, name, mode, created_at FROM chats WHERE user_id = %s ORDER BY id DESC",
+        (user_id,),
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+    return rows

--- a/packages/backend/tests/test_db.py
+++ b/packages/backend/tests/test_db.py
@@ -1,0 +1,74 @@
+"""Unit tests for chat/message persistence helpers in database.db.
+
+The helpers take a connection object, so we mock it — no real MySQL needed.
+"""
+from unittest.mock import MagicMock
+
+from database import db
+
+
+def _mock_cnx(lastrowid=None, fetchall=None):
+    cnx = MagicMock()
+    cursor = MagicMock()
+    cursor.lastrowid = lastrowid
+    cursor.fetchall.return_value = fetchall if fetchall is not None else []
+    cnx.cursor.return_value = cursor
+    return cnx, cursor
+
+
+def test_create_chat_inserts_and_returns_id():
+    cnx, cursor = _mock_cnx(lastrowid=42)
+    chat_id = db.create_chat(cnx, user_id=7, name="My Chat", mode="document")
+    assert chat_id == 42
+    sql, params = cursor.execute.call_args[0]
+    assert "INSERT INTO chats" in sql
+    assert params == (7, "My Chat", "document")
+    cursor.close.assert_called_once()
+
+
+def test_create_chat_defaults():
+    cnx, cursor = _mock_cnx(lastrowid=1)
+    db.create_chat(cnx, user_id=5)
+    _, params = cursor.execute.call_args[0]
+    assert params == (5, "New Chat", "chat")
+
+
+def test_add_message_inserts_and_returns_id():
+    cnx, cursor = _mock_cnx(lastrowid=99)
+    msg_id = db.add_message(
+        cnx, chat_id=42, role="user", content="hi", model="claude-sonnet-4-6", tokens=3
+    )
+    assert msg_id == 99
+    sql, params = cursor.execute.call_args[0]
+    assert "INSERT INTO messages" in sql
+    assert params == (42, "user", "hi", "claude-sonnet-4-6", 3)
+
+
+def test_add_message_defaults_model_and_tokens():
+    cnx, cursor = _mock_cnx(lastrowid=2)
+    db.add_message(cnx, chat_id=42, role="assistant", content="hello")
+    _, params = cursor.execute.call_args[0]
+    assert params == (42, "assistant", "hello", None, 0)
+
+
+def test_get_messages_chronological():
+    rows = [{"id": 1, "role": "user", "content": "hi"}]
+    cnx, cursor = _mock_cnx(fetchall=rows)
+    result = db.get_messages(cnx, chat_id=42)
+    assert result == rows
+    sql, params = cursor.execute.call_args[0]
+    assert "FROM messages WHERE chat_id" in sql
+    assert "ORDER BY id ASC" in sql
+    assert params == (42,)
+    cnx.cursor.assert_called_with(dictionary=True)
+
+
+def test_get_chats_most_recent_first():
+    rows = [{"id": 2, "name": "B"}, {"id": 1, "name": "A"}]
+    cnx, cursor = _mock_cnx(fetchall=rows)
+    result = db.get_chats(cnx, user_id=7)
+    assert result == rows
+    sql, params = cursor.execute.call_args[0]
+    assert "FROM chats WHERE user_id" in sql
+    assert "ORDER BY id DESC" in sql
+    assert params == (7,)


### PR DESCRIPTION
## What
Adds a chat/message persistence layer to `database/db.py` — the foundation for persistent conversation memory (#210) and RSI implicit-feedback (#220):

- `create_chat(cnx, user_id, name, mode)`
- `add_message(cnx, chat_id, role, content, model, tokens)`
- `get_messages(cnx, chat_id)` — chronological (oldest first)
- `get_chats(cnx, user_id)` — most recent first
- Unit tests with a mocked connection

They mirror the existing `create_user` / `get_user_by_email` style and target the `chats` / `messages` tables already defined in `schema.sql`.

## Why
The prod chat handler currently keeps sessions in memory (`_sessions` dict) — nothing is persisted, so **#210** (persistent conversation memory) and **#220** (RSI, which needs to read prior messages) can't actually land. The `chats`/`messages` schema exists but had no DB-access layer. This adds it.

## Scope — intentionally foundation-only
This PR is just the decision-free DB helpers + tests. It does **not** yet wire the chat handler / streaming to call them, because that involves a product decision — does chat require login? (`chats.user_id` is currently `NOT NULL`). Handler wiring will be a follow-up once that's settled.

## Verification
- Helper logic verified (SQL + params + return values) via a mocked connection
- `py_compile` clean
- `tests/test_db.py` runs under the Backend (lint + test) CI job
