### PR TITLE
Persist backend chat sessions

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -32,3 +32,4 @@ STRIPE_WEBHOOK_SECRET=
 # Storage
 UPLOAD_FOLDER=/tmp/anote_uploads
 CHROMA_PERSIST_DIR=./chroma_db
+CHAT_SESSION_DB_PATH=/tmp/anote_chat_sessions.sqlite3

--- a/packages/backend/api_endpoints/chat/handler.py
+++ b/packages/backend/api_endpoints/chat/handler.py
@@ -2,16 +2,33 @@
 from __future__ import annotations
 
 import os
-import uuid
 from collections.abc import Generator
 
-from flask import Blueprint, Response, jsonify, request, stream_with_context
+from flask import Blueprint, Response, current_app, jsonify, request, stream_with_context
 
-from services.streaming import stream_agent_response, stream_llm_response
+from services.chat_sessions import ChatSessionStore
+from services.streaming import sse_event, stream_agent_response, stream_llm_response
 
 chat_bp = Blueprint("chat", __name__, url_prefix="/api/chat")
 
-_sessions: dict[str, list[dict]] = {}
+
+def _store() -> ChatSessionStore:
+    return ChatSessionStore(current_app.config["CHAT_SESSION_DB_PATH"])
+
+
+def _title_from_message(message: str) -> str:
+    first_line = " ".join(message.strip().splitlines()[0:1]).strip()
+    if not first_line:
+        return "New chat"
+    return first_line[:77] + "..." if len(first_line) > 80 else first_line
+
+
+def _model_history(messages: list[dict]) -> list[dict]:
+    return [
+        {"role": m["role"], "content": m["content"]}
+        for m in messages
+        if m.get("role") in {"user", "assistant"} and m.get("content")
+    ]
 
 
 @chat_bp.post("/stream")
@@ -21,12 +38,35 @@ def chat_stream() -> Response:
     message: str = data.get("message", "").strip()
     cwd: str = data.get("cwd", os.getcwd())
     model: str = data.get("model", "claude-sonnet-4-6")
+    requested_session_id = data.get("session_id") or data.get("sessionId")
 
     if not message:
         return jsonify({"error": "message is required"}), 400  # type: ignore[return-value]
 
+    store = _store()
+    session = store.ensure_session(
+        str(requested_session_id) if requested_session_id else None,
+        title=_title_from_message(message),
+        cwd=cwd,
+        model=model,
+    )
+    session_id = session["id"]
+    history = _model_history(store.get_messages(session_id))
+    store.add_message(session_id, role="user", content=message, model=model)
+
     def generate() -> Generator[str, None, None]:
-        yield from stream_agent_response(message=message, cwd=cwd, model=model)
+        assistant_parts: list[str] = []
+        yield sse_event("session_id", {"session_id": session_id})
+        yield from stream_agent_response(
+            message=message,
+            cwd=cwd,
+            model=model,
+            history=history,
+            on_text=assistant_parts.append,
+        )
+        assistant_text = "".join(assistant_parts).strip()
+        if assistant_text:
+            store.add_message(session_id, role="assistant", content=assistant_text, model=model)
 
     return Response(
         stream_with_context(generate()),
@@ -46,13 +86,28 @@ def chat() -> tuple:
     message: str = data.get("message", "").strip()
     model: str = data.get("model", "claude-sonnet-4-6")
     history: list[dict] = data.get("history", [])
+    requested_session_id = data.get("session_id") or data.get("sessionId")
 
     if not message:
         return jsonify({"error": "message is required"}), 400
 
     try:
+        session_id = None
+        store = _store()
+        if requested_session_id:
+            session = store.ensure_session(
+                str(requested_session_id),
+                title=_title_from_message(message),
+                cwd=os.getcwd(),
+                model=model,
+            )
+            session_id = session["id"]
+            history = _model_history(store.get_messages(session_id))
         response_text = stream_llm_response(message=message, model=model, history=history)
-        return jsonify({"response": response_text, "model": model}), 200
+        if session_id:
+            store.add_message(session_id, role="user", content=message, model=model)
+            store.add_message(session_id, role="assistant", content=response_text, model=model)
+        return jsonify({"response": response_text, "model": model, "sessionId": session_id}), 200
     except Exception as exc:
         print(f"Chat error: {exc}")
         return jsonify({"error": "Internal server error"}), 500
@@ -60,24 +115,43 @@ def chat() -> tuple:
 
 @chat_bp.get("/sessions")
 def list_sessions() -> tuple:
-    return jsonify({"sessions": list(_sessions.keys())}), 200
+    return jsonify({"sessions": _store().list_sessions()}), 200
 
 
 @chat_bp.post("/sessions")
 def create_session() -> tuple:
-    session_id = str(uuid.uuid4())
-    _sessions[session_id] = []
-    return jsonify({"sessionId": session_id}), 201
+    data = request.get_json(silent=True) or {}
+    session = _store().create_session(
+        title=data.get("title") or "New chat",
+        cwd=data.get("cwd") or "",
+        model=data.get("model") or "",
+    )
+    return jsonify({"sessionId": session["id"], "session": session}), 201
 
 
 @chat_bp.get("/sessions/<session_id>")
 def get_session(session_id: str) -> tuple:
-    if session_id not in _sessions:
+    store = _store()
+    session = store.get_session(session_id)
+    if not session:
         return jsonify({"error": "Session not found"}), 404
-    return jsonify({"sessionId": session_id, "messages": _sessions[session_id]}), 200
+    return jsonify({
+        "sessionId": session_id,
+        "session": session,
+        "messages": store.get_messages(session_id),
+    }), 200
+
+
+@chat_bp.get("/sessions/<session_id>/messages")
+def get_session_messages(session_id: str) -> tuple:
+    store = _store()
+    if not store.get_session(session_id):
+        return jsonify({"error": "Session not found"}), 404
+    messages = store.get_messages(session_id)
+    return jsonify({"sessionId": session_id, "history": messages, "messages": messages}), 200
 
 
 @chat_bp.delete("/sessions/<session_id>")
 def delete_session(session_id: str) -> tuple:
-    _sessions.pop(session_id, None)
-    return jsonify({"deleted": True}), 200
+    deleted = _store().delete_session(session_id)
+    return jsonify({"deleted": deleted, "ok": deleted}), 200

--- a/packages/backend/app.py
+++ b/packages/backend/app.py
@@ -35,6 +35,10 @@ def create_app(config: dict | None = None) -> Flask:
         GEMINI_API_KEY=os.environ.get("GEMINI_API_KEY", ""),
         STRIPE_SECRET_KEY=os.environ.get("STRIPE_SECRET_KEY", ""),
         UPLOAD_FOLDER=os.environ.get("UPLOAD_FOLDER", "/tmp/anote_uploads"),
+        CHAT_SESSION_DB_PATH=os.environ.get(
+            "CHAT_SESSION_DB_PATH",
+            "/tmp/anote_chat_sessions.sqlite3",
+        ),
     )
     if config:
         app.config.update(config)

--- a/packages/backend/services/chat_sessions.py
+++ b/packages/backend/services/chat_sessions.py
@@ -1,0 +1,257 @@
+"""Persistent chat session storage backed by SQLite."""
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+MessageRole = Literal["user", "assistant", "system"]
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _iso(ts: int) -> str:
+    return datetime.fromtimestamp(ts, tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+class ChatSessionStore:
+    """Small SQLite-backed store for chat sessions and messages."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS chat_sessions (
+                    session_id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL DEFAULT 'New chat',
+                    cwd TEXT NOT NULL DEFAULT '',
+                    model TEXT NOT NULL DEFAULT '',
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS chat_messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+                    content TEXT NOT NULL,
+                    model TEXT NOT NULL DEFAULT '',
+                    created_at INTEGER NOT NULL,
+                    FOREIGN KEY (session_id) REFERENCES chat_sessions(session_id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_chat_messages_session_created
+                    ON chat_messages(session_id, created_at, id);
+                CREATE INDEX IF NOT EXISTS idx_chat_sessions_updated
+                    ON chat_sessions(updated_at);
+                """
+            )
+
+    def create_session(
+        self,
+        *,
+        session_id: str | None = None,
+        title: str = "New chat",
+        cwd: str = "",
+        model: str = "",
+    ) -> dict:
+        sid = session_id or str(uuid.uuid4())
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO chat_sessions
+                    (session_id, title, cwd, model, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (sid, title or "New chat", cwd or "", model or "", now, now),
+            )
+        session = self.get_session(sid)
+        if session is None:
+            raise RuntimeError("failed to create chat session")
+        return session
+
+    def ensure_session(
+        self,
+        session_id: str | None,
+        *,
+        title: str = "New chat",
+        cwd: str = "",
+        model: str = "",
+    ) -> dict:
+        if session_id:
+            existing = self.get_session(session_id)
+            if existing:
+                return existing
+        return self.create_session(session_id=session_id, title=title, cwd=cwd, model=model)
+
+    def list_sessions(self) -> list[dict]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    s.session_id,
+                    s.title,
+                    s.cwd,
+                    s.model,
+                    s.created_at,
+                    s.updated_at,
+                    COUNT(m.id) AS message_count
+                FROM chat_sessions s
+                LEFT JOIN chat_messages m ON m.session_id = s.session_id
+                GROUP BY s.session_id
+                ORDER BY s.updated_at DESC
+                """
+            ).fetchall()
+        return [self._session_from_row(row) for row in rows]
+
+    def get_session(self, session_id: str) -> dict | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT
+                    s.session_id,
+                    s.title,
+                    s.cwd,
+                    s.model,
+                    s.created_at,
+                    s.updated_at,
+                    COUNT(m.id) AS message_count
+                FROM chat_sessions s
+                LEFT JOIN chat_messages m ON m.session_id = s.session_id
+                WHERE s.session_id = ?
+                GROUP BY s.session_id
+                """,
+                (session_id,),
+            ).fetchone()
+        return self._session_from_row(row) if row else None
+
+    def add_message(
+        self,
+        session_id: str,
+        *,
+        role: MessageRole,
+        content: str,
+        model: str = "",
+    ) -> dict:
+        if role not in {"user", "assistant", "system"}:
+            raise ValueError(f"unsupported message role: {role}")
+
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO chat_messages (session_id, role, content, model, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (session_id, role, content, model or "", now),
+            )
+            if role == "user":
+                conn.execute(
+                    """
+                    UPDATE chat_sessions
+                    SET
+                        title = CASE
+                            WHEN title = 'New chat' THEN ?
+                            ELSE title
+                        END,
+                        model = CASE
+                            WHEN ? != '' THEN ?
+                            ELSE model
+                        END,
+                        updated_at = ?
+                    WHERE session_id = ?
+                    """,
+                    (self._title_from_message(content), model or "", model or "", now, session_id),
+                )
+            else:
+                conn.execute(
+                    """
+                    UPDATE chat_sessions
+                    SET
+                        model = CASE
+                            WHEN ? != '' THEN ?
+                            ELSE model
+                        END,
+                        updated_at = ?
+                    WHERE session_id = ?
+                    """,
+                    (model or "", model or "", now, session_id),
+                )
+            row = conn.execute("SELECT last_insert_rowid() AS id").fetchone()
+        return {
+            "id": str(row["id"]),
+            "role": role,
+            "content": content,
+            "model": model,
+            "createdAt": _iso(now),
+            "ts": now,
+        }
+
+    def get_messages(self, session_id: str) -> list[dict]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, role, content, model, created_at
+                FROM chat_messages
+                WHERE session_id = ?
+                ORDER BY created_at ASC, id ASC
+                """,
+                (session_id,),
+            ).fetchall()
+        return [
+            {
+                "id": str(row["id"]),
+                "role": row["role"],
+                "content": row["content"],
+                "model": row["model"],
+                "createdAt": _iso(int(row["created_at"])),
+                "ts": int(row["created_at"]),
+            }
+            for row in rows
+        ]
+
+    def delete_session(self, session_id: str) -> bool:
+        with self._connect() as conn:
+            cursor = conn.execute("DELETE FROM chat_sessions WHERE session_id = ?", (session_id,))
+        return cursor.rowcount > 0
+
+    @staticmethod
+    def _title_from_message(content: str) -> str:
+        first_line = " ".join(content.strip().splitlines()[0:1]).strip()
+        if not first_line:
+            return "New chat"
+        return first_line[:77] + "..." if len(first_line) > 80 else first_line
+
+    @staticmethod
+    def _session_from_row(row: sqlite3.Row) -> dict:
+        created_at = int(row["created_at"])
+        updated_at = int(row["updated_at"])
+        return {
+            "id": row["session_id"],
+            "sessionId": row["session_id"],
+            "title": row["title"],
+            "cwd": row["cwd"],
+            "model": row["model"],
+            "messageCount": int(row["message_count"]),
+            "createdAt": _iso(created_at),
+            "updatedAt": _iso(updated_at),
+            "created_at": created_at,
+            "updated_at": updated_at,
+        }

--- a/packages/backend/services/streaming.py
+++ b/packages/backend/services/streaming.py
@@ -3,17 +3,24 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 
 
-def _sse(event: str, data: dict) -> str:  # type: ignore[type-arg]
-    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+def sse_event(event: str, data: dict) -> str:  # type: ignore[type-arg]
+    """Format an SSE event with a client-friendly type field."""
+    payload = {"type": event, **data}
+    return f"event: {event}\ndata: {json.dumps(payload)}\n\n"
+
+
+_sse = sse_event
 
 
 def stream_agent_response(
     message: str,
     cwd: str = ".",
     model: str = "claude-sonnet-4-6",
+    history: list[dict] | None = None,  # type: ignore[type-arg]
+    on_text: Callable[[str], None] | None = None,
 ) -> Generator[str, None, None]:
     """Stream an agent response via SSE using the Anthropic SDK."""
     api_key = os.environ.get("ANTHROPIC_API_KEY", "")
@@ -26,9 +33,11 @@ def stream_agent_response(
         with client.messages.stream(
             model=model,
             max_tokens=4096,
-            messages=[{"role": "user", "content": message}],  # type: ignore[list-item]
+            messages=[*(history or []), {"role": "user", "content": message}],  # type: ignore[list-item]
         ) as stream:
             for text in stream.text_stream:
+                if on_text:
+                    on_text(text)
                 yield _sse("text", {"text": text})
         yield _sse("done", {})
     except Exception as exc:

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -11,13 +11,14 @@ from app import create_app  # noqa: E402
 
 
 @pytest.fixture
-def app():
+def app(tmp_path):
     return create_app({
         "TESTING": True,
         "JWT_SECRET_KEY": "test-secret",
         "DB_HOST": "localhost",
         "ANTHROPIC_API_KEY": "",
         "STRIPE_SECRET_KEY": "",
+        "CHAT_SESSION_DB_PATH": str(tmp_path / "chat_sessions.sqlite3"),
     })
 
 

--- a/packages/backend/tests/test_chat.py
+++ b/packages/backend/tests/test_chat.py
@@ -1,4 +1,9 @@
 """Tests for chat endpoints."""
+import json
+import re
+
+from services.chat_sessions import ChatSessionStore
+from services.streaming import sse_event
 
 
 def test_chat_stream_missing_message(client):
@@ -33,6 +38,7 @@ def test_get_session(client):
     resp = client.get(f"/api/chat/sessions/{sid}")
     assert resp.status_code == 200
     assert resp.get_json()["sessionId"] == sid
+    assert resp.get_json()["messages"] == []
 
 
 def test_get_session_not_found(client):
@@ -44,3 +50,44 @@ def test_delete_session(client):
     sid = client.post("/api/chat/sessions").get_json()["sessionId"]
     resp = client.delete(f"/api/chat/sessions/{sid}")
     assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+
+def test_session_store_persists_across_instances(tmp_path):
+    db_path = tmp_path / "sessions.sqlite3"
+    first = ChatSessionStore(db_path)
+    session = first.create_session(title="First chat")
+    first.add_message(session["id"], role="user", content="hello", model="claude")
+
+    second = ChatSessionStore(db_path)
+    assert second.get_session(session["id"])["messageCount"] == 1
+    assert second.get_messages(session["id"])[0]["content"] == "hello"
+
+
+def test_stream_chat_creates_session_and_persists_messages(client, monkeypatch):
+    def fake_stream_agent_response(*, on_text=None, **kwargs):
+        if on_text:
+            on_text("hello back")
+        yield sse_event("text", {"text": "hello back"})
+        yield sse_event("done", {})
+
+    monkeypatch.setattr(
+        "api_endpoints.chat.handler.stream_agent_response",
+        fake_stream_agent_response,
+    )
+
+    resp = client.post("/api/chat/stream", json={"message": "hello"})
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert '"type": "session_id"' in body
+    assert '"type": "text"' in body
+
+    match = re.search(r'data: ({"type": "session_id".*})', body)
+    assert match
+    session_id = json.loads(match.group(1))["session_id"]
+
+    session_resp = client.get(f"/api/chat/sessions/{session_id}")
+    assert session_resp.status_code == 200
+    messages = session_resp.get_json()["messages"]
+    assert [m["role"] for m in messages] == ["user", "assistant"]
+    assert messages[1]["content"] == "hello back"


### PR DESCRIPTION
## Summary
- Replaces in-memory backend chat session storage with a small SQLite-backed session/message store.
- Wires `/api/chat/stream` to create or reuse sessions, return `session_id`, and persist user/assistant messages.
- Makes SSE payloads include a `type` field so web, desktop, and mobile clients can consume streamed chunks consistently.
- Adds tests for persistence across store instances and streamed chat persistence.

## Why
The production chat path exposed session endpoints but only kept sessions in a process-local dict, so chat history disappeared across restarts and the frontend-provided `session_id` was not used by the backend.

## Validation
- `python3 -m ruff check packages/backend/api_endpoints/chat/handler.py packages/backend/services/chat_sessions.py packages/backend/services/streaming.py packages/backend/tests/test_chat.py packages/backend/tests/conftest.py`
- `/tmp/anote-backend-session-venv/bin/python -m pytest tests -q`
- Result: `82 passed, 14 warnings`
