### PR TITLE
Persist document metadata

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -32,3 +32,4 @@ STRIPE_WEBHOOK_SECRET=
 # Storage
 UPLOAD_FOLDER=/tmp/anote_uploads
 CHROMA_PERSIST_DIR=./chroma_db
+DOCUMENT_METADATA_DB_PATH=/tmp/anote_document_metadata.sqlite3

--- a/packages/backend/api_endpoints/documents/handler.py
+++ b/packages/backend/api_endpoints/documents/handler.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 import uuid
 from pathlib import Path
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 
+from services.document_store import DocumentStore
 from services.rag import ingest_document, query_documents
 
 documents_bp = Blueprint("documents", __name__, url_prefix="/api/documents")
-
-UPLOAD_FOLDER = Path("/tmp/anote_uploads")
-UPLOAD_FOLDER.mkdir(parents=True, exist_ok=True)
 
 # Map MIME types to safe extensions — extension never derived from user input
 _MIME_TO_EXT: dict[str, str] = {
@@ -22,7 +20,15 @@ _MIME_TO_EXT: dict[str, str] = {
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
 }
 
-_docs: dict[str, dict] = {}  # type: ignore[type-arg]
+
+def _store() -> DocumentStore:
+    return DocumentStore(current_app.config["DOCUMENT_METADATA_DB_PATH"])
+
+
+def _upload_folder() -> Path:
+    folder = Path(current_app.config["UPLOAD_FOLDER"])
+    folder.mkdir(parents=True, exist_ok=True)
+    return folder
 
 
 @documents_bp.post("/upload")
@@ -39,7 +45,7 @@ def upload() -> tuple:  # type: ignore[type-arg]
 
     doc_id = str(uuid.uuid4())
     # save_path uses only server-generated UUID + server-validated ext
-    save_path = UPLOAD_FOLDER / f"{doc_id}{ext}"
+    save_path = _upload_folder() / f"{doc_id}{ext}"
 
     try:
         file.save(save_path)
@@ -55,23 +61,24 @@ def upload() -> tuple:  # type: ignore[type-arg]
         return jsonify({"error": "Internal server error"}), 500
 
     original_name = file.filename or f"upload{ext}"
-    _docs[doc_id] = {
-        "id": doc_id,
-        "filename": original_name,
-        "path": str(save_path),
-        "chunks": chunk_count,
-    }
-    return jsonify(_docs[doc_id]), 201
+    document = _store().save_document(
+        doc_id=doc_id,
+        filename=original_name,
+        path=save_path,
+        chunks=chunk_count,
+        content_type=content_type,
+    )
+    return jsonify(document), 201
 
 
 @documents_bp.get("")
 def list_documents() -> tuple:  # type: ignore[type-arg]
-    return jsonify({"documents": list(_docs.values())}), 200
+    return jsonify({"documents": _store().list_documents()}), 200
 
 
 @documents_bp.get("/<doc_id>")
 def get_document(doc_id: str) -> tuple:  # type: ignore[type-arg]
-    doc = _docs.get(doc_id)
+    doc = _store().get_document(doc_id)
     if not doc:
         return jsonify({"error": "Document not found"}), 404
     return jsonify(doc), 200
@@ -79,7 +86,7 @@ def get_document(doc_id: str) -> tuple:  # type: ignore[type-arg]
 
 @documents_bp.delete("/<doc_id>")
 def delete_document(doc_id: str) -> tuple:  # type: ignore[type-arg]
-    doc = _docs.pop(doc_id, None)
+    doc = _store().delete_document(doc_id)
     if not doc:
         return jsonify({"error": "Document not found"}), 404
     Path(doc["path"]).unlink(missing_ok=True)
@@ -88,7 +95,7 @@ def delete_document(doc_id: str) -> tuple:  # type: ignore[type-arg]
 
 @documents_bp.post("/<doc_id>/ask")
 def ask_document(doc_id: str) -> tuple:  # type: ignore[type-arg]
-    if doc_id not in _docs:
+    if not _store().get_document(doc_id):
         return jsonify({"error": "Document not found"}), 404
     data = request.get_json(silent=True) or {}
     question = data.get("question", "").strip()

--- a/packages/backend/app.py
+++ b/packages/backend/app.py
@@ -35,6 +35,10 @@ def create_app(config: dict | None = None) -> Flask:
         GEMINI_API_KEY=os.environ.get("GEMINI_API_KEY", ""),
         STRIPE_SECRET_KEY=os.environ.get("STRIPE_SECRET_KEY", ""),
         UPLOAD_FOLDER=os.environ.get("UPLOAD_FOLDER", "/tmp/anote_uploads"),
+        DOCUMENT_METADATA_DB_PATH=os.environ.get(
+            "DOCUMENT_METADATA_DB_PATH",
+            "/tmp/anote_document_metadata.sqlite3",
+        ),
     )
     if config:
         app.config.update(config)

--- a/packages/backend/services/document_store.py
+++ b/packages/backend/services/document_store.py
@@ -1,0 +1,133 @@
+"""Persistent document metadata storage backed by SQLite."""
+from __future__ import annotations
+
+import sqlite3
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _iso(ts: int) -> str:
+    return datetime.fromtimestamp(ts, tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+class DocumentStore:
+    """Small SQLite store for uploaded document metadata."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS documents (
+                    id TEXT PRIMARY KEY,
+                    filename TEXT NOT NULL,
+                    path TEXT NOT NULL,
+                    chunks INTEGER NOT NULL DEFAULT 0,
+                    content_type TEXT NOT NULL DEFAULT '',
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_documents_updated
+                    ON documents(updated_at);
+                """
+            )
+
+    def save_document(
+        self,
+        *,
+        doc_id: str,
+        filename: str,
+        path: str | Path,
+        chunks: int,
+        content_type: str = "",
+    ) -> dict:
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO documents
+                    (id, filename, path, chunks, content_type, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    filename = excluded.filename,
+                    path = excluded.path,
+                    chunks = excluded.chunks,
+                    content_type = excluded.content_type,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    doc_id,
+                    filename or "upload",
+                    str(path),
+                    int(chunks),
+                    content_type or "",
+                    now,
+                    now,
+                ),
+            )
+        document = self.get_document(doc_id)
+        if document is None:
+            raise RuntimeError("failed to save document metadata")
+        return document
+
+    def list_documents(self) -> list[dict]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, filename, path, chunks, content_type, created_at, updated_at
+                FROM documents
+                ORDER BY updated_at DESC
+                """
+            ).fetchall()
+        return [self._document_from_row(row) for row in rows]
+
+    def get_document(self, doc_id: str) -> dict | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT id, filename, path, chunks, content_type, created_at, updated_at
+                FROM documents
+                WHERE id = ?
+                """,
+                (doc_id,),
+            ).fetchone()
+        return self._document_from_row(row) if row else None
+
+    def delete_document(self, doc_id: str) -> dict | None:
+        document = self.get_document(doc_id)
+        if document is None:
+            return None
+        with self._connect() as conn:
+            conn.execute("DELETE FROM documents WHERE id = ?", (doc_id,))
+        return document
+
+    @staticmethod
+    def _document_from_row(row: sqlite3.Row) -> dict:
+        created_at = int(row["created_at"])
+        updated_at = int(row["updated_at"])
+        return {
+            "id": row["id"],
+            "filename": row["filename"],
+            "path": row["path"],
+            "chunks": int(row["chunks"]),
+            "contentType": row["content_type"],
+            "createdAt": _iso(created_at),
+            "updatedAt": _iso(updated_at),
+            "created_at": created_at,
+            "updated_at": updated_at,
+        }

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -11,13 +11,15 @@ from app import create_app  # noqa: E402
 
 
 @pytest.fixture
-def app():
+def app(tmp_path):
     return create_app({
         "TESTING": True,
         "JWT_SECRET_KEY": "test-secret",
         "DB_HOST": "localhost",
         "ANTHROPIC_API_KEY": "",
         "STRIPE_SECRET_KEY": "",
+        "UPLOAD_FOLDER": str(tmp_path / "uploads"),
+        "DOCUMENT_METADATA_DB_PATH": str(tmp_path / "documents.sqlite3"),
     })
 
 

--- a/packages/backend/tests/test_documents.py
+++ b/packages/backend/tests/test_documents.py
@@ -1,6 +1,8 @@
 """Tests for document endpoints."""
 import io
 
+from services.document_store import DocumentStore
+
 
 def test_list_documents(client):
     resp = client.get("/api/documents")
@@ -48,3 +50,37 @@ def test_ask_document_missing_question(client):
     doc_id = up.get_json()["id"]
     resp = client.post(f"/api/documents/{doc_id}/ask", json={})
     assert resp.status_code == 400
+
+
+def test_document_store_persists_across_instances(tmp_path):
+    db_path = tmp_path / "documents.sqlite3"
+    first = DocumentStore(db_path)
+    first.save_document(
+        doc_id="doc-1",
+        filename="sample.txt",
+        path=tmp_path / "sample.txt",
+        chunks=3,
+        content_type="text/plain",
+    )
+
+    second = DocumentStore(db_path)
+    document = second.get_document("doc-1")
+    assert document["filename"] == "sample.txt"
+    assert document["chunks"] == 3
+
+
+def test_upload_persists_document_metadata(client, monkeypatch):
+    monkeypatch.setattr("api_endpoints.documents.handler.ingest_document", lambda **kwargs: 2)
+
+    data = {"file": (io.BytesIO(b"Content."), "doc.txt")}
+    upload = client.post("/api/documents/upload", data=data, content_type="multipart/form-data")
+    assert upload.status_code == 201
+    doc_id = upload.get_json()["id"]
+
+    listed = client.get("/api/documents").get_json()["documents"]
+    assert listed[0]["id"] == doc_id
+    assert listed[0]["chunks"] == 2
+
+    fetched = client.get(f"/api/documents/{doc_id}")
+    assert fetched.status_code == 200
+    assert fetched.get_json()["filename"] == "doc.txt"


### PR DESCRIPTION
## Summary
- Replaces process-local document metadata storage with a small SQLite-backed `DocumentStore`.
- Wires upload/list/get/delete/ask document endpoints through the persistent store.
- Moves upload folder lookup to Flask config so tests and deployments can control it.
- Adds persistence tests for the store and upload endpoint metadata flow.

## Why
Document uploads were saved to disk, but the metadata used by `/api/documents`, `/api/documents/<id>`, delete, and document Q&A lived only in the `_docs` in-memory dict. After a backend restart, uploaded documents were no longer discoverable through the API even if files and indexes still existed.

## Validation
- `python3 -m ruff check packages/backend/api_endpoints/documents/handler.py packages/backend/services/document_store.py packages/backend/tests/test_documents.py packages/backend/tests/conftest.py packages/backend/app.py`
- `/tmp/anote-backend-session-venv/bin/python -m pytest tests/test_documents.py -q`
- `/tmp/anote-backend-session-venv/bin/python -m pytest tests -q`
- Result: `82 passed, 14 warnings`
