### PR TITLE
feat(vscode): plan mode + web tools (WebSearch/WebFetch) — parity with CLI

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -176,6 +176,11 @@
           "default": false,
           "description": "Automatically accept file edits without confirmation"
         },
+        "anote.planMode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Plan mode: Anote researches and proposes a plan without editing files (read-only). Takes precedence over autoEdit when enabled."
+        },
         "anote.serverUrl": {
           "type": "string",
           "default": "",

--- a/packages/vscode/src/agent.ts
+++ b/packages/vscode/src/agent.ts
@@ -102,6 +102,10 @@ export class AnoteAgent {
     return vscode.workspace.getConfiguration("anote").get<boolean>("autoEdit") ?? false;
   }
 
+  private isPlanMode(): boolean {
+    return vscode.workspace.getConfiguration("anote").get<boolean>("planMode") ?? false;
+  }
+
   getCwdForWorkspace(): string {
     const folders = vscode.workspace.workspaceFolders;
     return folders && folders.length > 0 ? folders[0].uri.fsPath : process.cwd();
@@ -162,8 +166,12 @@ export class AnoteAgent {
 
     const options: Options = {
       cwd,
-      allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
-      permissionMode: this.isAutoEdit() ? "acceptEdits" : "default",
+      allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch", "WebFetch"],
+      permissionMode: this.isPlanMode()
+        ? "plan"
+        : this.isAutoEdit()
+          ? "acceptEdits"
+          : "default",
       systemPrompt,
       maxTurns: this.getMaxTurns(),
       model: getModel(),


### PR DESCRIPTION
## What
Brings the VS Code extension to parity with the CLI's plan mode + web tools (#253).

Before, the `packages/vscode` agent:
- `allowedTools` had only Read/Write/Edit/Bash/Glob/Grep — no web access
- `permissionMode` supported only default/acceptEdits — no plan mode

## Changes
- `agent.ts`: add `WebSearch`/`WebFetch` to `allowedTools`; add `isPlanMode()` and wire `permissionMode: 'plan'` (read-only planning, takes precedence over `autoEdit`)
- `package.json`: add `anote.planMode` boolean setting

## Notes
- Uses the existing SDK `Options` path — no new dependencies.
- `tsc -p tsconfig.json` passes locally.
- Mirrors CLI PR #253 so both surfaces behave consistently.
- Targeting `develop` per the new deployment flow.