### PR TITLE
feat(ci): develop-triggered CI/CD pipeline to prod EC2 (per 7/13 deployment session)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,106 +1,152 @@
 name: Deploy
 
+# CI/CD pipeline for the Panacea prod EC2 ("Private Chatbot" instance), per the
+# 7/13 deployment session: push to develop -> run tests -> build Docker images
+# -> push to ECR -> SSH into the prod EC2 and restart containers.
+#
+# Required repo secrets (to be configured before this pipeline can run):
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY - IAM user with ECR push access
+#   AWS_ACCOUNT_ID                            - for the ECR registry URL
+#   PROD_EC2_HOST / PROD_EC2_USER / PROD_EC2_SSH_KEY - prod instance SSH access
+
 on:
+  push:
+    branches: [develop]
   workflow_dispatch:
-    inputs:
-      environment:
-        description: "Target environment"
-        required: true
-        default: production
-        type: choice
-        options: [production, staging]
 
 concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: false
 
-jobs:
-  deploy-backend:
-    name: Deploy Backend to ECS
-    runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment || 'production' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
-      - name: Login to ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build and push backend image
-        working-directory: packages/backend
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: autonomous-intelligence-backend
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-                     $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-      - name: Deploy to ECS
-        env:
-          ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
-          ECS_SERVICE: ${{ secrets.ECS_SERVICE_BACKEND }}
-        run: |
-          aws ecs update-service \
-            --cluster $ECS_CLUSTER \
-            --service $ECS_SERVICE \
-            --force-new-deployment
-          aws ecs wait services-stable \
-            --cluster $ECS_CLUSTER \
-            --services $ECS_SERVICE
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY_BACKEND: panacea-backend
+  ECR_REPOSITORY_WEB: panacea-web
 
-  deploy-frontend:
-    name: Deploy Frontend to S3/CloudFront
+jobs:
+  test:
+    name: Test (gate)
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment || 'production' }}
-    needs: deploy-backend
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: packages/backend/requirements.txt
+
+      - name: Install backend dependencies
+        working-directory: packages/backend
+        run: pip install -r requirements.txt
+
+      - name: Backend tests
+        working-directory: packages/backend
+        run: pytest tests/ -q
+        env:
+          APP_ENV: test
+          DB_HOST: localhost
+          JWT_SECRET_KEY: test-secret
+
       - uses: actions/setup-node@v4
         with:
           node-version: "20.19.0"
           cache: npm
           cache-dependency-path: packages/web/package-lock.json
-      - name: Install dependencies
+
+      - name: Web build check
         working-directory: packages/web
-        run: npm ci
-      - name: Build
-        working-directory: packages/web
-        run: npm run build
+        run: |
+          npm ci
+          npm run build
+
+  build-and-push:
+    name: Build and push images to ECR
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: test
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
-      - name: Deploy to S3
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push backend image
+        working-directory: packages/backend
         env:
-          S3_BUCKET: ${{ secrets.S3_BUCKET_FRONTEND }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
-          aws s3 sync packages/web/dist/ s3://$S3_BUCKET --delete \
-            --cache-control "public, max-age=31536000, immutable" \
-            --exclude "index.html" --exclude "*.json"
-          aws s3 cp packages/web/dist/index.html s3://$S3_BUCKET/index.html \
-            --cache-control "no-cache, no-store, must-revalidate"
-          aws s3 sync packages/web/dist/ s3://$S3_BUCKET \
-            --exclude "*" --include "*.json" --cache-control "no-cache"
-      - name: Invalidate CloudFront
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_BACKEND:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_BACKEND:$IMAGE_TAG \
+                     $ECR_REGISTRY/$ECR_REPOSITORY_BACKEND:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_BACKEND:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_BACKEND:latest
+
+      - name: Build and push web image
+        working-directory: packages/web
         env:
-          CF_DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
-          aws cloudfront create-invalidation \
-            --distribution-id $CF_DISTRIBUTION --paths "/*"
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_WEB:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_WEB:$IMAGE_TAG \
+                     $ECR_REGISTRY/$ECR_REPOSITORY_WEB:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_WEB:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_WEB:latest
+
+  deploy:
+    name: Deploy to prod EC2
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build-and-push
+    environment: production
+    steps:
+      - name: SSH into EC2 and restart containers
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.PROD_EC2_HOST }}
+          username: ${{ secrets.PROD_EC2_USER }}
+          key: ${{ secrets.PROD_EC2_SSH_KEY }}
+          script: |
+            set -e
+            REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+            aws ecr get-login-password --region us-east-1 \
+              | docker login --username AWS --password-stdin $REGISTRY
+
+            # Backend (gunicorn on 5000)
+            docker pull $REGISTRY/panacea-backend:${{ github.sha }}
+            docker stop panacea-backend || true
+            docker rm panacea-backend || true
+            docker run -d --name panacea-backend --restart unless-stopped \
+              -p 5000:5000 \
+              --env-file $HOME/panacea/.env \
+              $REGISTRY/panacea-backend:${{ github.sha }}
+
+            # Web (nginx serving the built app, container 3000 -> host 80)
+            docker pull $REGISTRY/panacea-web:${{ github.sha }}
+            docker stop panacea-web || true
+            docker rm panacea-web || true
+            docker run -d --name panacea-web --restart unless-stopped \
+              -p 80:3000 \
+              $REGISTRY/panacea-web:${{ github.sha }}
+
+            docker image prune -f
 
   notify:
     name: Notify on Failure
     runs-on: ubuntu-latest
-    needs: [deploy-backend, deploy-frontend]
+    needs: [test, build-and-push, deploy]
     if: failure()
     steps:
       - uses: slackapi/slack-github-action@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,11 +124,16 @@ jobs:
             aws ecr get-login-password --region us-east-1 \
               | docker login --username AWS --password-stdin $REGISTRY
 
+            # Shared network: web's nginx proxies /api, /auth and /health to
+            # http://backend:5000, so both containers must resolve "backend".
+            docker network create panacea 2>/dev/null || true
+
             # Backend (gunicorn on 5000)
             docker pull $REGISTRY/panacea-backend:${{ github.sha }}
             docker stop panacea-backend || true
             docker rm panacea-backend || true
             docker run -d --name panacea-backend --restart unless-stopped \
+              --network panacea --network-alias backend \
               -p 5000:5000 \
               --env-file $HOME/panacea/.env \
               $REGISTRY/panacea-backend:${{ github.sha }}
@@ -138,6 +143,7 @@ jobs:
             docker stop panacea-web || true
             docker rm panacea-web || true
             docker run -d --name panacea-web --restart unless-stopped \
+              --network panacea \
               -p 80:3000 \
               $REGISTRY/panacea-web:${{ github.sha }}
 


### PR DESCRIPTION
## What

Replaces the manual ECS/S3 deploy workflow with the **test → build-and-push → deploy** pipeline from the 7/13 deployment session with Bi Rong:

- **Trigger**: push to `develop` (plus manual `workflow_dispatch`)
- **test (gate)**: backend `pytest` + web `npm run build` — pipeline stops here on failure
- **build-and-push**: builds `packages/backend` and `packages/web` Docker images, pushes to ECR tagged with the commit SHA + `latest`
- **deploy**: SSHes into the prod EC2, pulls the new images, restarts containers (backend gunicorn on 5000 reading env from the instance's `.env`; web nginx container 3000 → host 80)
- Keeps the Slack failure notification and `environment: production` (so approval rules can be added later)

## Before merging

The secrets listed at the top of the workflow file need to be configured first:
`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_ACCOUNT_ID` / `PROD_EC2_HOST` / `PROD_EC2_USER` / `PROD_EC2_SSH_KEY`

This is currently blocked on repo settings access + AWS credentials (from the session's blocker list). Until then the pipeline will fail at `build-and-push`.

## Open question

The old workflow deployed to **ECS**; the deployment guide + session decision point to **EC2** (the `Private Chatbot` instance). This PR follows the EC2 path — please confirm, or I can switch it back to ECS.

Refs: 7/13 deployment session (Bi Rong's 3-job `deploy.yml` template), #257.