### PR TITLE
test(backend): raise coverage 81% → 92% (workspaces, db, auth, documents)

### DIFF
--- a/packages/backend/tests/test_db_and_auth.py
+++ b/packages/backend/tests/test_db_and_auth.py
@@ -1,0 +1,239 @@
+"""Tests for the DB helpers and auth/document edge cases.
+
+The DB layer talks to MySQL, which isn't available in CI, so these tests drive
+the helpers with a lightweight fake connection/cursor rather than a real DB.
+"""
+from __future__ import annotations
+
+import pytest
+
+from database import db
+
+
+class FakeCursor:
+    def __init__(self, fetch_result=None, lastrowid=None):
+        self._fetch_result = fetch_result
+        self.lastrowid = lastrowid
+        self.executed: list[tuple] = []
+        self.closed = False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchone(self):
+        return self._fetch_result
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self, dictionary=False):
+        return self._cursor
+
+    def close(self):
+        pass
+
+
+def test_get_user_by_email_found():
+    row = {"id": 7, "email": "a@b.com"}
+    cur = FakeCursor(fetch_result=row)
+    cnx = FakeConnection(cur)
+    assert db.get_user_by_email(cnx, "a@b.com") == row
+    assert cur.closed is True
+    # Query is parameterized — email is bound, never interpolated.
+    sql, params = cur.executed[0]
+    assert params == ("a@b.com",)
+
+
+def test_get_user_by_email_missing():
+    cur = FakeCursor(fetch_result=None)
+    assert db.get_user_by_email(FakeConnection(cur), "none@x.com") is None
+
+
+def test_create_user_returns_new_id():
+    cur = FakeCursor(lastrowid=42)
+    new_id = db.create_user(FakeConnection(cur), "a@b.com", "hash", "Alice")
+    assert new_id == 42
+    assert cur.closed is True
+    sql, params = cur.executed[0]
+    assert params == ("a@b.com", "hash", "Alice")
+
+
+def test_get_connection_without_mysql(monkeypatch):
+    """When the driver isn't installed, get_connection raises a clear error."""
+    monkeypatch.setattr(db, "MYSQL_AVAILABLE", False)
+    with pytest.raises(RuntimeError, match="mysql-connector-python"):
+        db.get_connection()
+
+
+# --- auth handler edge cases (the DB-unavailable fallback branches) ---
+
+def test_register_missing_fields(client):
+    assert client.post("/auth/register", json={}).status_code == 400
+
+
+def test_register_short_password(client):
+    resp = client.post("/auth/register", json={"email": "a@b.com", "password": "short"})
+    assert resp.status_code == 400
+
+
+def test_register_falls_back_without_db(client):
+    """With no DB reachable, register still issues a token via the fallback."""
+    resp = client.post(
+        "/auth/register", json={"email": "new@x.com", "password": "longenough"}
+    )
+    assert resp.status_code == 201
+    assert "token" in resp.get_json()
+
+
+def test_login_missing_fields(client):
+    assert client.post("/auth/login", json={}).status_code == 400
+
+
+def test_login_service_unavailable_without_db(client):
+    """No DB reachable -> login surfaces a 503, not a 500."""
+    resp = client.post("/auth/login", json={"email": "a@b.com", "password": "whatever"})
+    assert resp.status_code == 503
+
+
+def test_register_success_with_db(client, monkeypatch):
+    """Happy path: no existing user, create_user issues id, real bcrypt hash."""
+    from database import db as db_mod
+
+    monkeypatch.setattr(db_mod, "get_connection", lambda: FakeConnection(FakeCursor()))
+    monkeypatch.setattr(db_mod, "get_user_by_email", lambda cnx, email: None)
+    monkeypatch.setattr(db_mod, "create_user", lambda cnx, e, h, n: 99)
+
+    resp = client.post(
+        "/auth/register", json={"email": "New@X.com", "password": "longenough", "name": "N"}
+    )
+    assert resp.status_code == 201
+    assert resp.get_json()["userId"] == 99
+
+
+def test_register_email_already_exists(client, monkeypatch):
+    from database import db as db_mod
+
+    monkeypatch.setattr(db_mod, "get_connection", lambda: FakeConnection(FakeCursor()))
+    monkeypatch.setattr(db_mod, "get_user_by_email", lambda cnx, email: {"id": 1})
+
+    resp = client.post(
+        "/auth/register", json={"email": "dup@x.com", "password": "longenough"}
+    )
+    assert resp.status_code == 409
+
+
+def test_login_success_with_db(client, monkeypatch):
+    """Real bcrypt round-trip: hash a password, then log in with it."""
+    from api_endpoints.auth import handler as auth_handler
+    from database import db as db_mod
+
+    pw = "correct-horse"
+    hashed = auth_handler._hash_password(pw)
+    user = {"id": 5, "password_hash": hashed}
+
+    monkeypatch.setattr(db_mod, "get_connection", lambda: FakeConnection(FakeCursor()))
+    monkeypatch.setattr(db_mod, "get_user_by_email", lambda cnx, email: user)
+
+    resp = client.post("/auth/login", json={"email": "a@b.com", "password": pw})
+    assert resp.status_code == 200
+    assert resp.get_json()["userId"] == 5
+
+
+def test_login_wrong_password(client, monkeypatch):
+    from api_endpoints.auth import handler as auth_handler
+    from database import db as db_mod
+
+    user = {"id": 5, "password_hash": auth_handler._hash_password("right")}
+    monkeypatch.setattr(db_mod, "get_connection", lambda: FakeConnection(FakeCursor()))
+    monkeypatch.setattr(db_mod, "get_user_by_email", lambda cnx, email: user)
+
+    resp = client.post("/auth/login", json={"email": "a@b.com", "password": "wrong"})
+    assert resp.status_code == 401
+
+
+def test_me_requires_auth(client):
+    assert client.get("/auth/me").status_code == 401
+
+
+def test_me_with_token(client, auth_headers):
+    resp = client.get("/auth/me", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.get_json()["userId"] == "1"
+
+
+# --- document handler edge cases ---
+
+def test_upload_no_file(client):
+    assert client.post("/api/documents/upload").status_code == 400
+
+
+def test_get_document_not_found(client):
+    assert client.get("/api/documents/nope").status_code == 404
+
+
+def test_delete_document_not_found(client):
+    assert client.delete("/api/documents/nope").status_code == 404
+
+
+def test_ask_document_not_found(client):
+    resp = client.post("/api/documents/nope/ask", json={"question": "hi"})
+    assert resp.status_code == 404
+
+
+def test_upload_unsupported_type(client):
+    import io
+
+    data = {"file": (io.BytesIO(b"binary"), "x.exe", "application/octet-stream")}
+    resp = client.post("/api/documents/upload", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 400
+
+
+def test_upload_and_ask_success(client, monkeypatch):
+    """Happy path with RAG mocked: upload a .txt, then ask a question."""
+    import io
+
+    from api_endpoints.documents import handler as doc_handler
+
+    monkeypatch.setattr(doc_handler, "ingest_document", lambda doc_id, file_path: 3)
+    monkeypatch.setattr(
+        doc_handler, "query_documents", lambda question, doc_ids, model: "the answer"
+    )
+
+    data = {"file": (io.BytesIO(b"hello world"), "notes.txt", "text/plain")}
+    up = client.post("/api/documents/upload", data=data, content_type="multipart/form-data")
+    assert up.status_code == 201
+    doc_id = up.get_json()["id"]
+    assert up.get_json()["chunks"] == 3
+
+    # It now appears in the listing and is fetchable.
+    assert any(d["id"] == doc_id for d in client.get("/api/documents").get_json()["documents"])
+    assert client.get(f"/api/documents/{doc_id}").status_code == 200
+
+    ask = client.post(f"/api/documents/{doc_id}/ask", json={"question": "what?"})
+    assert ask.status_code == 200
+    assert ask.get_json()["answer"] == "the answer"
+
+    # Missing question is a 400 even for a real doc.
+    assert client.post(f"/api/documents/{doc_id}/ask", json={}).status_code == 400
+
+    # And it can be deleted.
+    assert client.delete(f"/api/documents/{doc_id}").status_code == 200
+
+
+def test_upload_ingest_failure_returns_500(client, monkeypatch):
+    import io
+
+    from api_endpoints.documents import handler as doc_handler
+
+    def boom(doc_id, file_path):
+        raise RuntimeError("parse failed")
+
+    monkeypatch.setattr(doc_handler, "ingest_document", boom)
+    data = {"file": (io.BytesIO(b"hi"), "notes.txt", "text/plain")}
+    resp = client.post("/api/documents/upload", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 500

--- a/packages/backend/tests/test_workspaces.py
+++ b/packages/backend/tests/test_workspaces.py
@@ -1,0 +1,117 @@
+"""Tests for the workspace API — hosted-mode CRUD and git clone paths.
+
+The blueprint computes HOSTED_MODE at import time from ANOTE_MODE, so these
+tests monkeypatch the module-level flag (and the in-memory store) to exercise
+the hosted-only branches that the default non-hosted config never reaches.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from api_endpoints.workspaces import handler as ws_handler
+
+
+@pytest.fixture
+def hosted(monkeypatch, tmp_path):
+    """Enable hosted mode with an isolated workspace dir and empty store."""
+    monkeypatch.setattr(ws_handler, "HOSTED_MODE", True)
+    monkeypatch.setattr(ws_handler, "WORKSPACES_DIR", tmp_path)
+    monkeypatch.setattr(ws_handler, "_workspaces", {})
+
+
+def test_list_empty(client, hosted):
+    resp = client.get("/api/workspaces")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"workspaces": []}
+
+
+def test_create_requires_name(client, hosted):
+    resp = client.post("/api/workspaces", json={})
+    assert resp.status_code == 400
+
+
+def test_create_and_list(client, hosted):
+    resp = client.post("/api/workspaces", json={"name": "my-project"})
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body["name"] == "my-project"
+    ws_id = body["id"]
+
+    listed = client.get("/api/workspaces").get_json()["workspaces"]
+    assert any(w["id"] == ws_id for w in listed)
+
+
+def test_get_workspace(client, hosted):
+    ws_id = client.post("/api/workspaces", json={"name": "w"}).get_json()["id"]
+    resp = client.get(f"/api/workspaces/{ws_id}")
+    assert resp.status_code == 200
+    assert resp.get_json()["id"] == ws_id
+
+
+def test_get_workspace_not_found(client, hosted):
+    resp = client.get("/api/workspaces/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_delete_workspace(client, hosted):
+    ws_id = client.post("/api/workspaces", json={"name": "w"}).get_json()["id"]
+    resp = client.delete(f"/api/workspaces/{ws_id}")
+    assert resp.status_code == 200
+    assert resp.get_json()["deleted"] is True
+    # Second delete now 404s — it's gone from the store.
+    assert client.delete(f"/api/workspaces/{ws_id}").status_code == 404
+
+
+def test_delete_workspace_not_found(client, hosted):
+    resp = client.delete("/api/workspaces/nope")
+    assert resp.status_code == 404
+
+
+def test_clone_not_found(client, hosted):
+    resp = client.post("/api/workspaces/nope/clone", json={"repoUrl": "https://x/y.git"})
+    assert resp.status_code == 404
+
+
+def test_clone_requires_repo_url(client, hosted):
+    ws_id = client.post("/api/workspaces", json={"name": "w"}).get_json()["id"]
+    resp = client.post(f"/api/workspaces/{ws_id}/clone", json={})
+    assert resp.status_code == 400
+
+
+def test_clone_success(client, hosted, monkeypatch):
+    ws_id = client.post("/api/workspaces", json={"name": "w"}).get_json()["id"]
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 0, b"", b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    resp = client.post(
+        f"/api/workspaces/{ws_id}/clone", json={"repoUrl": "https://github.com/x/y.git"}
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["cloned"] is True
+
+
+def test_clone_git_failure(client, hosted, monkeypatch):
+    ws_id = client.post("/api/workspaces", json={"name": "w"}).get_json()["id"]
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "git", stderr=b"fatal: repo not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    resp = client.post(
+        f"/api/workspaces/{ws_id}/clone", json={"repoUrl": "https://github.com/x/y.git"}
+    )
+    assert resp.status_code == 500
+    assert "repo not found" in resp.get_json()["error"]
+
+
+def test_all_endpoints_blocked_in_non_hosted(client):
+    """Without hosted mode every workspace route returns 501."""
+    assert client.get("/api/workspaces").status_code == 501
+    assert client.post("/api/workspaces", json={"name": "w"}).status_code == 501
+    assert client.get("/api/workspaces/x").status_code == 501
+    assert client.delete("/api/workspaces/x").status_code == 501
+    assert client.post("/api/workspaces/x/clone", json={}).status_code == 501


### PR DESCRIPTION
Adds test coverage for the backend modules with the biggest gaps, per Friday's deployment session (Bi Rong / Natan asked everyone to write test cases so the CI/CD gate has margin). Coverage was sitting right on the 80% gate — any new code risked dropping below it and blocking deploys.

| Module | Before | After |
|---|---|---|
| `workspaces/handler.py` | 38% | **100%** |
| `database/db.py` | 58% | 92% |
| `auth/handler.py` | 70% | 95% |
| `documents/handler.py` | 74% | 91% |
| **TOTAL** | **81%** | **92%** |

What's covered:
- **workspaces**: hosted-mode CRUD, git clone success/failure (mocked subprocess), non-hosted 501 guards
- **db**: user query/create helpers via a fake connection, driver-missing error path
- **auth**: register/login DB paths with a real bcrypt round-trip, duplicate-email 409, wrong-password 401
- **documents**: upload + ask happy path (RAG mocked), unsupported type, ingest failure

Test-only — no production code touched. 114 passing locally, ruff + mypy clean.