### PR TITLE
feat: add release verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
           DB_HOST: localhost
           JWT_SECRET_KEY: test-secret
 
+      - name: Test release smoke tooling
+        working-directory: .
+        run: python -m unittest discover -s scripts/tests
+
   # ── TypeScript packages ───────────────────────────────────────────────────────
   typescript:
     name: TypeScript (build + test)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,9 @@ jobs:
           ECR_REPOSITORY: autonomous-intelligence-backend
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build \
+            --build-arg BUILD_SHA=$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
                      $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -70,6 +72,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
         run: npm run build --workspace=packages/web
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -94,6 +98,22 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
             --distribution-id $CF_DISTRIBUTION --paths "/*"
+      - name: Verify production release
+        if: ${{ github.event.inputs.environment == 'production' }}
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          for attempt in {1..6}; do
+            python3 scripts/release_smoke.py \
+              --frontend-url https://chat.anote.ai \
+              --api-url https://chat.anote.ai \
+              --expected-sha "$EXPECTED_SHA" \
+              --require-payments && exit 0
+            if [[ "$attempt" -lt 6 ]]; then
+              sleep 10
+            fi
+          done
+          exit 1
 
   notify:
     name: Notify on Failure

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,53 @@
+name: Production Smoke Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      frontend_url:
+        description: "Public Panacea frontend URL"
+        required: true
+        default: "https://chat.anote.ai"
+        type: string
+      api_url:
+        description: "Public origin that routes Panacea API paths"
+        required: true
+        default: "https://chat.anote.ai"
+        type: string
+      expected_sha:
+        description: "Expected frontend and backend commit SHA (optional)"
+        required: false
+        type: string
+      require_payments:
+        description: "Require at least one configured Stripe paid plan"
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  smoke:
+    name: Verify public release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run read-only smoke checks
+        env:
+          FRONTEND_URL: ${{ inputs.frontend_url }}
+          API_URL: ${{ inputs.api_url }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          REQUIRE_PAYMENTS: ${{ inputs.require_payments }}
+        run: |
+          args=(
+            --frontend-url "$FRONTEND_URL"
+            --api-url "$API_URL"
+          )
+          if [[ -n "$EXPECTED_SHA" ]]; then
+            args+=(--expected-sha "$EXPECTED_SHA")
+          fi
+          if [[ "$REQUIRE_PAYMENTS" == "true" ]]; then
+            args+=(--require-payments)
+          fi
+          python scripts/release_smoke.py "${args[@]}"

--- a/RELEASE_VERIFICATION.md
+++ b/RELEASE_VERIFICATION.md
@@ -1,0 +1,47 @@
+# Panacea Release Verification
+
+Every deployed frontend and backend build exposes public, non-secret metadata so
+the running release can be matched to a Git commit:
+
+- Frontend: `GET /build.json`
+- Backend: `GET /health` and `GET /api/version`
+
+The deployment workflow injects the GitHub commit SHA into both images. The
+frontend uses `VITE_BUILD_SHA`; the backend Docker image uses
+`PANACEA_BUILD_SHA`.
+
+## Run the production smoke test
+
+The checker only sends `GET` requests. It does not create users, upload files,
+start payment sessions, or mutate production data.
+
+```bash
+python scripts/release_smoke.py \
+  --frontend-url https://chat.anote.ai \
+  --api-url https://chat.anote.ai \
+  --expected-sha "$EXPECTED_SHA" \
+  --require-payments
+```
+
+It verifies:
+
+- the public frontend loads and identifies Panacea;
+- frontend and backend build metadata match the expected commit;
+- the API health endpoint is healthy;
+- protected auth, document, and usage endpoints reject anonymous requests;
+- the billing plans endpoint returns its expected JSON shape;
+- at least one Stripe-backed paid plan is available when
+  `--require-payments` is set.
+
+Use the **Production Smoke Test** GitHub Actions workflow to run the same checks
+manually after a deployment. A failure should block release sign-off until the
+reported endpoint or build mismatch is resolved.
+
+## Local tests
+
+```bash
+python -m unittest discover -s scripts/tests -v
+```
+
+The smoke checker uses only the Python standard library and performs normal TLS
+certificate and hostname verification.

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.11-slim
 
+ARG BUILD_SHA=unknown
+ARG APP_VERSION=1.0.0
+
+ENV PANACEA_BUILD_SHA=${BUILD_SHA} \
+    PANACEA_VERSION=${APP_VERSION}
+
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/packages/backend/app.py
+++ b/packages/backend/app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 
-from flask import Flask, jsonify
+from flask import Flask, Response, jsonify
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 
@@ -15,9 +15,10 @@ from api_endpoints.payments.handler import payments_bp
 from api_endpoints.search.handler import search_bp
 from api_endpoints.user.handler import user_bp
 from api_endpoints.workspaces.handler import workspaces_bp
+from build_metadata import get_build_metadata
 
 
-def create_app(config: dict | None = None) -> Flask:
+def create_app(config: dict[str, object] | None = None) -> Flask:
     """Create and configure the Flask application."""
     app = Flask(__name__)
 
@@ -53,12 +54,17 @@ def create_app(config: dict | None = None) -> Flask:
     app.register_blueprint(workspaces_bp)
 
     @app.get("/health")
-    def health() -> tuple:
-        return jsonify({"status": "ok", "service": "anote-backend"}), 200
+    def health() -> tuple[Response, int]:
+        return jsonify({"status": "ok", **get_build_metadata()}), 200
+
+    @app.get("/version")
+    @app.get("/api/version")
+    def version() -> tuple[Response, int]:
+        return jsonify(get_build_metadata()), 200
 
     @app.get("/")
-    def root() -> tuple:
-        return jsonify({"name": "Anote AI Backend", "version": "1.0.0"}), 200
+    def root() -> tuple[Response, int]:
+        return jsonify({"name": "Anote AI Backend", **get_build_metadata()}), 200
 
     return app
 

--- a/packages/backend/build_metadata.py
+++ b/packages/backend/build_metadata.py
@@ -1,0 +1,28 @@
+"""Build metadata shared by health and version endpoints."""
+from __future__ import annotations
+
+import os
+
+DEFAULT_VERSION = "1.0.0"
+UNKNOWN_COMMIT = "unknown"
+
+_COMMIT_ENV_VARS = (
+    "PANACEA_BUILD_SHA",
+    "GITHUB_SHA",
+    "COMMIT_SHA",
+    "SOURCE_VERSION",
+)
+
+
+def get_build_metadata() -> dict[str, str]:
+    """Return public, non-secret metadata identifying the running build."""
+    commit = next(
+        (os.environ[name].strip() for name in _COMMIT_ENV_VARS if os.environ.get(name, "").strip()),
+        UNKNOWN_COMMIT,
+    )
+    version = os.environ.get("PANACEA_VERSION", DEFAULT_VERSION).strip() or DEFAULT_VERSION
+    return {
+        "service": "anote-backend",
+        "version": version,
+        "commit": commit,
+    }

--- a/packages/backend/tests/test_health.py
+++ b/packages/backend/tests/test_health.py
@@ -1,17 +1,49 @@
 """Tests for health endpoints."""
 
 
-def test_health(client):
+def test_health(client, monkeypatch):
+    monkeypatch.setenv("PANACEA_BUILD_SHA", "abc123")
+    monkeypatch.setenv("PANACEA_VERSION", "1.2.3")
+
     resp = client.get("/health")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["status"] == "ok"
     assert data["service"] == "anote-backend"
+    assert data["version"] == "1.2.3"
+    assert data["commit"] == "abc123"
 
 
-def test_root(client):
+def test_version_uses_safe_fallbacks(client, monkeypatch):
+    for name in ("PANACEA_BUILD_SHA", "GITHUB_SHA", "COMMIT_SHA", "SOURCE_VERSION"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("PANACEA_VERSION", raising=False)
+
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.get_json() == {
+        "service": "anote-backend",
+        "version": "1.0.0",
+        "commit": "unknown",
+    }
+    assert client.get("/version").get_json() == resp.get_json()
+
+
+def test_version_accepts_common_ci_sha(client, monkeypatch):
+    monkeypatch.delenv("PANACEA_BUILD_SHA", raising=False)
+    monkeypatch.setenv("GITHUB_SHA", "github-sha")
+
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.get_json()["commit"] == "github-sha"
+
+
+def test_root(client, monkeypatch):
+    monkeypatch.setenv("PANACEA_BUILD_SHA", "root-sha")
+
     resp = client.get("/")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert "name" in data
-    assert "version" in data
+    assert data["name"] == "Anote AI Backend"
+    assert data["version"] == "1.0.0"
+    assert data["commit"] == "root-sha"

--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:20.19.0-slim AS build
 
+ARG BUILD_SHA=unknown
+ARG APP_VERSION=1.0.0
+
+ENV VITE_BUILD_SHA=${BUILD_SHA} \
+    VITE_APP_VERSION=${APP_VERSION}
+
 WORKDIR /app
 
 # Copy root workspace files first so npm can resolve hoisted dependencies

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,8 +1,30 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const buildMetadata = {
+  service: "panacea-web",
+  version: process.env.VITE_APP_VERSION || "1.0.0",
+  commit:
+    process.env.VITE_BUILD_SHA ||
+    process.env.GITHUB_SHA ||
+    process.env.COMMIT_SHA ||
+    "unknown",
+};
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: "panacea-build-metadata",
+      generateBundle() {
+        this.emitFile({
+          type: "asset",
+          fileName: "build.json",
+          source: `${JSON.stringify(buildMetadata, null, 2)}\n`,
+        });
+      },
+    },
+  ],
   server: {
     port: 3000,
     proxy: {

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository automation utilities."""

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Read-only production smoke checks for Panacea web and API releases."""
+from __future__ import annotations
+
+import argparse
+import json
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from typing import Any
+from urllib.parse import urljoin
+
+
+@dataclass(frozen=True)
+class Response:
+    status: int
+    content_type: str
+    body: bytes
+
+    def json(self) -> Any:
+        return json.loads(self.body.decode("utf-8"))
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    ok: bool
+    detail: str
+
+
+def _url(base: str, path: str) -> str:
+    return urljoin(f"{base.rstrip('/')}/", path.lstrip("/"))
+
+
+def fetch(url: str, timeout: float) -> Response:
+    """Fetch a public URL with normal browser-grade TLS verification."""
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "PanaceaReleaseSmoke/1.0"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return Response(
+                status=response.status,
+                content_type=response.headers.get("Content-Type", ""),
+                body=response.read(),
+            )
+    except urllib.error.HTTPError as exc:
+        try:
+            return Response(
+                status=exc.code,
+                content_type=exc.headers.get("Content-Type", ""),
+                body=exc.read(),
+            )
+        finally:
+            exc.close()
+
+
+def _matches_sha(actual: str, expected: str) -> bool:
+    return actual == expected or actual.startswith(expected) or expected.startswith(actual)
+
+
+def _get(
+    name: str,
+    base: str,
+    path: str,
+    timeout: float,
+    expected_status: int,
+    expected_type: str,
+) -> tuple[Check, Response | None]:
+    url = _url(base, path)
+    try:
+        response = fetch(url, timeout)
+    except (OSError, ssl.SSLError, urllib.error.URLError) as exc:
+        return Check(name, False, f"{url}: {type(exc).__name__}: {exc}"), None
+
+    if response.status != expected_status:
+        return (
+            Check(name, False, f"{url}: expected HTTP {expected_status}, got {response.status}"),
+            response,
+        )
+    if expected_type not in response.content_type.lower():
+        return (
+            Check(
+                name,
+                False,
+                f"{url}: expected {expected_type} content, got "
+                f"{response.content_type or 'no Content-Type'}",
+            ),
+            response,
+        )
+    return Check(name, True, f"{url}: HTTP {response.status}"), response
+
+
+def _json_check(
+    name: str,
+    base: str,
+    path: str,
+    timeout: float,
+    expected_status: int = 200,
+) -> tuple[Check, dict[str, Any] | None]:
+    check, response = _get(
+        name,
+        base,
+        path,
+        timeout,
+        expected_status=expected_status,
+        expected_type="application/json",
+    )
+    if not check.ok or response is None:
+        return check, None
+    try:
+        payload = response.json()
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return Check(name, False, f"{_url(base, path)}: invalid JSON: {exc}"), None
+    if not isinstance(payload, dict):
+        return Check(name, False, f"{_url(base, path)}: expected a JSON object"), None
+    return check, payload
+
+
+def run_checks(
+    frontend_url: str,
+    api_url: str,
+    timeout: float = 10.0,
+    expected_sha: str | None = None,
+    require_payments: bool = False,
+) -> list[Check]:
+    """Run public, read-only checks without creating users or payment sessions."""
+    checks: list[Check] = []
+
+    frontend_check, frontend = _get(
+        "frontend",
+        frontend_url,
+        "/",
+        timeout,
+        expected_status=200,
+        expected_type="text/html",
+    )
+    if frontend_check.ok and frontend is not None and b"Panacea" not in frontend.body:
+        frontend_check = Check(
+            "frontend",
+            False,
+            f"{_url(frontend_url, '/')}: HTML does not identify Panacea",
+        )
+    checks.append(frontend_check)
+
+    web_build_check, web_build = _json_check(
+        "frontend-build-metadata",
+        frontend_url,
+        "/build.json",
+        timeout,
+    )
+    checks.append(web_build_check)
+
+    health_check, health = _json_check("api-health", api_url, "/health", timeout)
+    if health_check.ok and health is not None and health.get("status") != "ok":
+        health_check = Check("api-health", False, "API health payload does not report status=ok")
+    checks.append(health_check)
+
+    api_build_check, api_build = _json_check(
+        "api-build-metadata",
+        api_url,
+        "/api/version",
+        timeout,
+    )
+    checks.append(api_build_check)
+
+    for name, path in (
+        ("auth-protection", "/auth/me"),
+        ("document-protection", "/api/documents"),
+        ("usage-protection", "/api/user/usage"),
+    ):
+        check, _ = _json_check(name, api_url, path, timeout, expected_status=401)
+        checks.append(check)
+
+    plans_check, plans = _json_check(
+        "billing-plans",
+        api_url,
+        "/api/payments/plans",
+        timeout,
+    )
+    if plans_check.ok and plans is not None:
+        plan_rows = plans.get("plans")
+        if not isinstance(plan_rows, list):
+            plans_check = Check("billing-plans", False, "Billing payload has no plans list")
+        elif require_payments and not any(
+            isinstance(plan, dict) and plan.get("available") for plan in plan_rows
+        ):
+            plans_check = Check(
+                "billing-plans",
+                False,
+                "No paid plan is configured; expected at least one available Stripe price",
+            )
+    checks.append(plans_check)
+
+    if expected_sha:
+        for name, payload in (
+            ("frontend-expected-commit", web_build),
+            ("api-expected-commit", api_build),
+        ):
+            actual = payload.get("commit") if payload else None
+            ok = isinstance(actual, str) and _matches_sha(actual, expected_sha)
+            checks.append(
+                Check(
+                    name,
+                    ok,
+                    f"expected {expected_sha}, got {actual or 'unavailable'}",
+                )
+            )
+
+    return checks
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--frontend-url", required=True)
+    parser.add_argument("--api-url", required=True)
+    parser.add_argument("--expected-sha")
+    parser.add_argument("--require-payments", action="store_true")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    checks = run_checks(
+        frontend_url=args.frontend_url,
+        api_url=args.api_url,
+        timeout=args.timeout,
+        expected_sha=args.expected_sha,
+        require_payments=args.require_payments,
+    )
+    if args.json_output:
+        print(json.dumps([asdict(check) for check in checks], indent=2))
+    else:
+        for check in checks:
+            marker = "PASS" if check.ok else "FAIL"
+            print(f"[{marker}] {check.name}: {check.detail}")
+        passed = sum(check.ok for check in checks)
+        print(f"\n{passed}/{len(checks)} checks passed")
+    return 0 if all(check.ok for check in checks) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for repository automation utilities."""

--- a/scripts/tests/test_release_smoke.py
+++ b/scripts/tests/test_release_smoke.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from scripts.release_smoke import run_checks
+
+
+class _Handler(BaseHTTPRequestHandler):
+    routes: dict[str, tuple[int, str, bytes]] = {}
+
+    def do_GET(self) -> None:  # noqa: N802
+        status, content_type, body = self.routes.get(
+            self.path,
+            (404, "application/json", b'{"error":"not found"}'),
+        )
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def _json(payload: object) -> bytes:
+    return json.dumps(payload).encode()
+
+
+class ReleaseSmokeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        _Handler.routes = {
+            "/": (200, "text/html", b"<title>Panacea</title>"),
+            "/build.json": (
+                200,
+                "application/json",
+                _json({"service": "panacea-web", "version": "1.0.0", "commit": "abc123"}),
+            ),
+            "/health": (
+                200,
+                "application/json",
+                _json({"status": "ok", "service": "anote-backend"}),
+            ),
+            "/api/version": (
+                200,
+                "application/json",
+                _json({"service": "anote-backend", "version": "1.0.0", "commit": "abc123"}),
+            ),
+            "/auth/me": (401, "application/json", _json({"msg": "missing token"})),
+            "/api/documents": (401, "application/json", _json({"error": "unauthorized"})),
+            "/api/user/usage": (401, "application/json", _json({"msg": "missing token"})),
+            "/api/payments/plans": (
+                200,
+                "application/json",
+                _json({"plans": [{"plan": "basic", "available": True}]}),
+            ),
+        }
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.base_url = f"http://127.0.0.1:{cls.server.server_port}"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join(timeout=2)
+
+    def test_all_checks_pass_for_a_matching_release(self) -> None:
+        checks = run_checks(
+            self.base_url,
+            self.base_url,
+            expected_sha="abc123",
+            require_payments=True,
+        )
+        self.assertTrue(all(check.ok for check in checks), checks)
+
+    def test_expected_sha_mismatch_is_reported(self) -> None:
+        checks = run_checks(self.base_url, self.base_url, expected_sha="different")
+        failed = {check.name for check in checks if not check.ok}
+        self.assertEqual(
+            failed,
+            {"frontend-expected-commit", "api-expected-commit"},
+        )
+
+    def test_payment_configuration_can_be_required(self) -> None:
+        original = _Handler.routes["/api/payments/plans"]
+        _Handler.routes["/api/payments/plans"] = (
+            200,
+            "application/json",
+            _json({"plans": [{"plan": "basic", "available": False}]}),
+        )
+        try:
+            checks = run_checks(
+                self.base_url,
+                self.base_url,
+                require_payments=True,
+            )
+        finally:
+            _Handler.routes["/api/payments/plans"] = original
+        billing = next(check for check in checks if check.name == "billing-plans")
+        self.assertFalse(billing.ok)
+        self.assertIn("No paid plan", billing.detail)
+
+    def test_spa_html_cannot_masquerade_as_api_health(self) -> None:
+        original = _Handler.routes["/health"]
+        _Handler.routes["/health"] = (200, "text/html", b"<title>Panacea</title>")
+        try:
+            checks = run_checks(self.base_url, self.base_url)
+        finally:
+            _Handler.routes["/health"] = original
+        health = next(check for check in checks if check.name == "api-health")
+        self.assertFalse(health.ok)
+        self.assertIn("expected application/json", health.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- expose public, non-secret build metadata from the backend and generated frontend bundle
- inject the deployed Git commit into backend and frontend builds
- add a read-only production smoke checker for frontend, API health, build identity, anonymous-route protection, and billing-plan availability
- add manual and post-deploy GitHub Actions verification with bounded retries
- document the release verification procedure and test the checker in CI

## Why

The deployment pipeline could finish without proving which commit was actually running or whether CloudFront API routes were returning backend JSON instead of the SPA fallback. This made release sign-off dependent on manual inspection and allowed routing, authentication, or billing configuration gaps to go undetected.

This change adds deterministic build identity and a GET-only release gate. It does not create users, upload documents, initiate payment sessions, or mutate production data.

## Impact

Reviewers and operators can match the live frontend and backend to a Git SHA and run the same verification locally, manually in Actions, or automatically after a production deployment. A failed verification marks the deployment job failed and triggers the existing failure notification.

The current production deployment predates this metadata and presently returns HTML for the checked same-origin API paths, so the live smoke check is expected to remain red until the relevant deployment and routing configuration are updated.

## Validation

- `make test`
- `make lint`
- backend: 230 tests passed, 85.80% coverage
- release smoke unit tests: 4 passed
- web production build and Vitest passed
- Ruff, Mypy, workflow YAML parsing, and `git diff --check` passed
