### PR TITLE
Add Cookbook browsing page to the web app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,6 +1875,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@textlint/ast-node-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
@@ -10185,6 +10212,7 @@
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.20",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^6.0.2",
@@ -10272,6 +10300,7 @@
     "@anote-ai/web": {
       "version": "file:packages/web",
       "requires": {
+        "@tailwindcss/typography": "^0.5.20",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^6.0.2",
@@ -11364,6 +11393,27 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
     },
+    "@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+          "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        }
+      }
+    },
     "@textlint/ast-node-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
@@ -11706,7 +11756,7 @@
         "read": "^1.0.7",
         "secretlint": "^10.1.2",
         "semver": "^7.5.2",
-        "tmp": "^0.2.7",
+        "tmp": "^0.2.3",
         "typed-rest-client": "^1.8.4",
         "url-join": "^4.0.1",
         "xml2js": "^0.5.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,16 +9,17 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "axios": "^1.6.0",
+    "clsx": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.0",
-    "axios": "^1.6.0",
-    "react-markdown": "^9.0.0",
     "react-helmet-async": "^2.0.5",
-    "remark-gfm": "^4.0.0",
-    "clsx": "^2.1.0"
+    "react-markdown": "^9.0.0",
+    "react-router-dom": "^6.22.0",
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.20",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^6.0.2",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ChatPage from "./pages/ChatPage";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
+import CookbookPage from "./pages/CookbookPage";
 import LandingPage from "./landing_page/LandingPage.js";
 import ContactPage from "./landing_page/ContactPage.js";
 import PrivacyPolicyPage from "./landing_page/PrivacyPolicyPage.js";
@@ -67,6 +68,8 @@ export default function App() {
             <Route path="/case-studies" element={<CaseStudiesPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
+            <Route path="/cookbook" element={<Navigate to="/cookbook/03-panacea-document-qa-rag" replace />} />
+            <Route path="/cookbook/:slug" element={<CookbookPage />} />
             <Route path="/app" element={<RequireAuth><ChatPage /></RequireAuth>} />
             <Route path="/app/chat/:id" element={<RequireAuth><ChatPage /></RequireAuth>} />
           </Routes>

--- a/packages/web/src/cookbook/manifest.ts
+++ b/packages/web/src/cookbook/manifest.ts
@@ -1,0 +1,29 @@
+export interface CookbookRecipe {
+  slug: string;
+  name: string;
+  group: "platform";
+  runnable: boolean;
+}
+
+// Mirrors Cookbook/README.md's recipe table. Content lives in ./recipes/<slug>.md,
+// copied verbatim from the Cookbook repo.
+export const COOKBOOK_RECIPES: CookbookRecipe[] = [
+  { slug: "03-panacea-document-qa-rag", name: "Document Q&A + RAG", group: "platform", runnable: false },
+  { slug: "04-panacea-multi-agent-orchestration", name: "Multi-Agent Orchestration", group: "platform", runnable: false },
+  { slug: "05-panacea-ai-coding-toolchain", name: "AI Coding Toolchain", group: "platform", runnable: false },
+  { slug: "06-panacea-multimodal-ingestion", name: "Multi-Modal Ingestion", group: "platform", runnable: false },
+  { slug: "07-panacea-openai-compatible-gateway", name: "OpenAI-Compatible Gateway", group: "platform", runnable: false },
+  { slug: "08-panacea-billing-and-api-keys", name: "Billing & API Keys", group: "platform", runnable: false },
+  { slug: "09-panacea-mcp-tool-server", name: "MCP Tool Server", group: "platform", runnable: false },
+  { slug: "10-panacea-messaging-bots", name: "Multi-Channel Messaging Bots", group: "platform", runnable: false },
+];
+
+const recipeSources = import.meta.glob("./recipes/*.md", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+export function getRecipeContent(slug: string): string {
+  return recipeSources[`./recipes/${slug}.md`] ?? "";
+}

--- a/packages/web/src/cookbook/recipes/03-panacea-document-qa-rag.md
+++ b/packages/web/src/cookbook/recipes/03-panacea-document-qa-rag.md
@@ -1,0 +1,95 @@
+# Panacea Document Q&A + RAG
+
+This recipe explains how Panacea builds private document question-answering with retrieval-augmented generation (RAG).
+
+## What you'll learn
+
+- How Panacea ingests documents and stores them as searchable text
+- How the backend retrieves relevant chunks for a question
+- How the system uses embeddings and document sources to ground answers
+- How Q&A feedback is captured and improves future responses
+
+## Why this matters
+
+Panacea is designed to let teams ask questions of private documents without sending them to a third-party chat service. The workflow is:
+
+1. Upload documents
+2. Chunk and embed content
+3. Retrieve relevant chunks for a user query
+4. Answer using an LLM with citations
+5. Capture feedback to improve quality
+
+## Key Panacea files
+
+| File | Why it matters |
+|---|---|
+| `Panacea/backend/api_endpoints/documents/handler.py` | Document upload and ingestion API routes |
+| `Panacea/backend/database/db.py` | Document storage and retrieval SQL logic |
+| `Panacea/backend/database/qa_feedback.py` | Feedback capture for document Q&A |
+| `Panacea/backend/agents/multi_agent_system.py` | Document retrieval agents used in multi-agent workflows |
+
+## How it works
+
+- Documents are uploaded through the backend and stored in `documents.document_text`.
+- The system chunks large documents and creates retrieval metadata for fast lookup.
+- When a user asks a question, Panacea selects one or more specialized agents to retrieve the best chunks and then generates an answer.
+- The result includes source citations so users can trace the answer back to the original document.
+- Feedback signals are logged in `qa_feedback` to enable future quality improvements.
+
+## Run it locally
+
+From the workspace root (`anote/panacea`):
+
+```bash
+cd Panacea
+cp backend/.env.example backend/.env
+docker compose up --build
+```
+
+This starts the backend, web app, MySQL, Redis, and Tika.
+
+If you are already inside the recipe folder, use:
+
+```bash
+cd ../../../Panacea
+cp backend/.env.example backend/.env
+docker compose up --build
+```
+
+Open `http://localhost:3000` to use the Panacea web UI. Document uploads are handled by the backend route `POST /ingest-pdf` with the required form fields `chat_id` and `files[]`.
+
+Example upload command:
+
+```bash
+curl -X POST http://localhost:5000/ingest-pdf \
+  -F chat_id=1 \
+  -F "files[]=@./path/to/document.pdf"
+```
+
+### Minimal upload walkthrough
+
+1. Start Panacea from the repo root:
+
+```bash
+cd Panacea
+cp backend/.env.example backend/.env
+docker compose up --build
+```
+
+2. In another terminal, upload a single text or PDF document:
+
+```bash
+curl -X POST http://localhost:5000/ingest-pdf \
+  -F chat_id=1 \
+  -F "files[]=@./Cookbook/recipes/03-panacea-document-qa-rag/data/sample-doc.txt"
+```
+
+3. Confirm the backend returns a successful `Document Uploaded` response.
+
+4. Use the web UI at `http://localhost:3000` and select the same chat session to ask questions about the uploaded document.
+
+If you want to test the API directly after upload, find the chat session ID in the UI or database and send questions through the app's chat flow. Panacea will retrieve relevant chunks and generate a grounded answer.
+
+## Notes for the cookbook
+
+This recipe is ideal for a cookbook entry that explains how Panacea supports private knowledge work. It is more conceptual than a one-line script, because the real value is understanding the document ingestion and retrieval architecture.

--- a/packages/web/src/cookbook/recipes/04-panacea-multi-agent-orchestration.md
+++ b/packages/web/src/cookbook/recipes/04-panacea-multi-agent-orchestration.md
@@ -1,0 +1,75 @@
+# Panacea Multi-Agent Orchestration
+
+This recipe explains Panacea’s agent orchestration architecture: how the orchestrator assigns tasks, picks agents, and supports sequential and hierarchical workflows.
+
+## What you'll learn
+
+- The role of the orchestrator as the system brain
+- How Panacea routes tasks to specialized agents
+- The difference between sequential and hierarchical workflows
+- How crews of agents collaborate on a shared goal
+- How tool registration works so agents can use new capabilities
+
+## Why this matters
+
+In Panacea, the orchestrator is not random. It chooses the best agent based on capability descriptions, task context, and workflow state. That makes the system predictable and extensible.
+
+## Key concepts
+
+- **Orchestrator** — central coordinator that decides which agent runs next
+- **Agent** — autonomous unit with a defined purpose, such as `DocumentRetrievalAgent`, `GeneralKnowledgeAgent`, or `ChatHistoryAgent`
+- **Crew** — a group of agents working together toward a common objective
+- **Workflows** — the collaboration style; can be:
+  - **Sequential**: one step follows another in order
+  - **Hierarchical**: a chain of command where the orchestrator delegates subtasks to specialists
+- **Tools** — functions agents can call to perform actions like searching, uploading, or executing code
+
+## Key Panacea files
+
+| File | Why it matters |
+|---|---|
+| `Panacea/backend/agents/multi_agent_system.py` | Orchestrator and workflow routing logic |
+| `Panacea/backend/agents/autonomous_agent.py` | Tool registration and agent lifecycle |
+| `Panacea/backend/agents/routing.py` | Task-routing helper logic |
+| `Panacea/backend/agents/reactive_agent.py` | Initializes the multi-agent system and connects it to chat flows |
+
+## How it works
+
+1. A user submits a task or query.
+2. The orchestrator agent reviews the input and chooses a next agent based on capabilities and task requirements.
+3. Specialized agents execute their part of the pipeline and may return intermediate results.
+4. The orchestrator may either continue sequentially or keep delegating sub-tasks in a hierarchical pattern.
+5. The final result is assembled and returned to the user.
+
+### Sequential workflow
+
+A sequential workflow is useful for fixed pipelines such as:
+
+- retrieve document chunks → summarize → answer user
+- gather code context → analyze code → return review suggestions
+
+Each step runs in order, and the next step uses the previous step’s output.
+
+### Hierarchical workflow
+
+A hierarchical workflow is useful for complex tasks where the orchestrator manages specialists:
+
+- orchestrator assigns one agent to gather data
+- another agent validates the data
+- a third agent generates the final response
+
+This is similar to a chain of command: the orchestrator stays in control and delegates work to subject-matter agents.
+
+## Tool registration
+
+Panacea supports dynamic tool registration. If an agent needs a new capability, it can call `register_tool(...)` from `backend/agents/autonomous_agent.py`.
+
+That means the cookbook can document not only how to use existing tools, but how to add new tools to the system.
+
+## Feedback loop
+
+User feedback is essential for improving agent selection. Panacea logs feedback from document Q&A and task results so the orchestrator can learn which agents and tools produce the best outcomes.
+
+## Notes for the cookbook
+
+This recipe is a strong candidate for a manual explanation. It should include diagrams or step-by-step flow examples that show why the orchestrator makes decisions instead of leaving agent selection to chance.

--- a/packages/web/src/cookbook/recipes/05-panacea-ai-coding-toolchain.md
+++ b/packages/web/src/cookbook/recipes/05-panacea-ai-coding-toolchain.md
@@ -1,0 +1,70 @@
+# Panacea AI Coding Toolchain
+
+This recipe explains how Panacea’s AI coding experience is delivered across CLI, SDK, and VS Code.
+
+## What you'll learn
+
+- The different AI coding entry points in Panacea
+- How the CLI, SDK, and VS Code extension relate to the shared backend
+- Key product capabilities for private code assistance
+- Where to look in the repo for implementation details
+
+## Why this matters
+
+Panacea is built as a unified product with multiple interfaces:
+
+- a **CLI** that powers `anote chat`, code search, and repo review
+- a **VS Code extension** for in-editor AI assistance
+- a **SDK** for embedding Panacea into other applications
+
+These interfaces share a backend and agent-driven reasoning layer, which makes the product consistent across desktop, web, and code workflows.
+
+## Key Panacea files
+
+| File | Why it matters |
+|---|---|
+| `Panacea/packages/cli` | TypeScript CLI implementation for developer workflows |
+| `Panacea/packages/vscode` | VS Code extension and chat integration |
+| `Panacea/packages/sdk` | TypeScript SDK for programmatic access |
+| `Panacea/packages/backend` | Shared backend service powering all UI and CLI interactions |
+
+## How it works
+
+- A coding user action starts at the CLI, SDK, or VS Code extension.
+- The request is sent to Panacea’s backend API.
+- The backend uses agent orchestration and model providers to produce code-aware answers.
+- The response is returned in the same interface, with code suggestions, explanations, or fixes.
+
+## Useful product features
+
+- **CLI**: `anote chat`, repo search, code review, code generation, and embeddings-powered assistance.
+- **VS Code**: inline chat, diff previews, code actions, and streaming responses.
+- **SDK**: a client wrapper for the Panacea API, enabling custom integrations.
+
+## Run it locally
+
+From the workspace root (`anote/panacea`):
+
+```bash
+cd Panacea
+cp packages/backend/.env.example packages/backend/.env
+docker compose up --build
+```
+
+This starts the shared backend and frontend services.
+
+In another terminal, run the CLI package:
+
+```bash
+cd Panacea/packages/cli
+npm install
+npm run dev
+```
+
+Then you can use the CLI locally or build it with `npm run build`.
+
+For VS Code development, open `Panacea/packages/vscode` in VS Code and launch the extension with the debugger.
+
+## Notes for the cookbook
+
+This recipe is useful for teammates who need a high-level walkthrough of Panacea’s multi-interface AI coding product. It can also point readers to implementation files they can modify or extend.

--- a/packages/web/src/cookbook/recipes/06-panacea-multimodal-ingestion.md
+++ b/packages/web/src/cookbook/recipes/06-panacea-multimodal-ingestion.md
@@ -1,0 +1,78 @@
+# Panacea Multi-Modal Document Ingestion
+
+This recipe explains how Panacea extends document Q&A + RAG (see [recipe 03](../03-panacea-document-qa-rag/)) beyond plain text to images, audio, video, and spreadsheets — making all of them searchable through the same chunking and embedding pipeline.
+
+## What you'll learn
+
+- How Panacea classifies an upload by MIME type and routes it to a dedicated ingestion service
+- How images and video frames are turned into indexable text using a vision-capable LLM
+- How audio (including the audio track of a video) is transcribed with Whisper
+- How spreadsheets are converted into Markdown tables instead of being flattened into an unsearchable text dump
+- The feature flags and size limits that govern multi-modal ingestion
+
+## Why this matters
+
+Tika (the default document-text extractor) can only usefully handle text-based formats. Without extra handling, an uploaded image, audio clip, video, or spreadsheet would either fail to ingest or lose all of its structure. Panacea instead detects the media type at upload time and calls a purpose-built service that produces clean text, which is then stored as `document_text` and flows through the exact same retrieval path as any other document — so a screenshot, a call recording, or a sales spreadsheet all become answerable through chat like a PDF would.
+
+## Key Panacea files
+
+| File | Why it matters |
+|---|---|
+| `Panacea/backend/api_endpoints/documents/handler.py` | Detects MIME type/extension on upload and routes to the right ingestion service |
+| `Panacea/backend/services/vision_service.py` | `describe_image()` — produces a detailed text description of an image using GPT-4o or Claude vision |
+| `Panacea/backend/services/audio_service.py` | `transcribe_audio()` — transcribes audio with OpenAI Whisper |
+| `Panacea/backend/services/video_service.py` | Extracts frames with `ffmpeg`, describes each with the vision service, transcribes the audio track, and interleaves both |
+| `Panacea/backend/services/tabular_service.py` | `ingest_tabular()` — converts CSV/TSV/XLSX/XLS/ODS into Markdown tables that preserve headers and rows |
+| `Panacea/backend/agents/config.py` | `AgentConfig` feature flags: `ENABLE_MULTIMODAL`, `MAX_IMAGE_BYTES`, `MAX_AUDIO_BYTES`, `MAX_VIDEO_BYTES`, `VIDEO_FRAME_INTERVAL_SECS`, `VIDEO_MAX_FRAMES` |
+
+## How it works
+
+1. A file is uploaded through the same endpoint used for regular documents; `handler.py` sniffs the MIME type/extension to classify it as image, video, audio, tabular, or plain text/document.
+2. **Image** → `vision_service.describe_image()` sends the image (base64-encoded) to a vision-capable model with a prompt instructing it to transcribe any visible text, describe charts/diagrams/UI screenshots, and note objects and layout — so the description alone is enough for semantic search to find it later.
+3. **Audio** → `audio_service.transcribe_audio()` calls Whisper (`whisper-1`) and returns a transcript with duration/language metadata.
+4. **Video** → `video_service` extracts frames at a fixed interval (`VIDEO_FRAME_INTERVAL_SECS`, default 30s, capped at `VIDEO_MAX_FRAMES`) using `ffmpeg`, describes each frame with the vision service, transcribes the audio track separately, and interleaves both into one timestamped document.
+5. **Tabular** → `tabular_service.ingest_tabular()` parses each sheet natively (via `csv`/`pandas`+`openpyxl`/`xlrd`) and renders it as a Markdown table, falling back to plain CSV for rows beyond the first 500 so nothing is lost from the search index even if it isn't rendered nicely.
+6. Whatever text comes out of any of these services is stored as `document_text` and chunked/embedded exactly like a normal document, so it is retrievable through the standard RAG Q&A flow from recipe 03.
+
+Every service is designed to **never raise** — a failed vision call, a missing dependency, or an oversized file returns a placeholder string (e.g. `"[Image too large for inline analysis (23.4 MB). Limit: 20 MB.]"`) so the document record is always created instead of failing the whole upload.
+
+## Run it locally
+
+From the workspace root (`anote/panacea`):
+
+```bash
+cd Panacea
+cp backend/.env.example backend/.env
+docker compose up --build
+```
+
+Multi-modal ingestion is on by default (`ENABLE_MULTIMODAL=true`). Set these in `backend/.env` to adjust behavior:
+
+```bash
+ENABLE_MULTIMODAL=true        # master switch
+MAX_IMAGE_BYTES=20971520      # 20 MB default
+MAX_AUDIO_BYTES=26214400      # 25 MB default
+MAX_VIDEO_BYTES=524288000     # 500 MB default
+VIDEO_FRAME_INTERVAL_SECS=30
+VIDEO_MAX_FRAMES=20
+```
+
+Video ingestion additionally requires `ffmpeg` to be present on the backend container's `PATH` (already included in the provided Docker image). Excel ingestion requires `openpyxl` (XLSX/ODS) and `xlrd` (legacy XLS), and both vision/audio services need `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY` set depending on `DEFAULT_AGENT_MODEL_TYPE`.
+
+### Try it
+
+```bash
+curl -X POST http://localhost:5000/ingest-pdf \
+  -F chat_id=1 \
+  -F "files[]=@./screenshot.png"
+
+curl -X POST http://localhost:5000/ingest-pdf \
+  -F chat_id=1 \
+  -F "files[]=@./quarterly_sales.xlsx"
+```
+
+Then, in the web UI at `http://localhost:3000`, open the same chat session and ask a question about the image or spreadsheet you just uploaded — Panacea answers from the generated description/Markdown table exactly as it would from a PDF.
+
+## Notes for the cookbook
+
+This recipe pairs well with recipe 03: it's the same RAG pipeline, just with a wider funnel of input formats. Worth calling out to readers that the "index quality" for images/video is only as good as the vision model's description, so prompt tuning in `vision_service.py`'s `_INDEXING_PROMPT` is a natural customization point.

--- a/packages/web/src/cookbook/recipes/07-panacea-openai-compatible-gateway.md
+++ b/packages/web/src/cookbook/recipes/07-panacea-openai-compatible-gateway.md
@@ -1,0 +1,103 @@
+# Panacea OpenAI-Compatible API Gateway
+
+This recipe explains how to point any tool built against the OpenAI SDK at Panacea instead — with zero code changes — while still getting access to Panacea-specific RAG extensions like grounded document sources.
+
+## What you'll learn
+
+- How `AnoteOpenAI` mirrors the real `openai.OpenAI` client's interface
+- How to upload documents and get document-grounded answers through a chat-completions-shaped API
+- How streaming works over Server-Sent Events (SSE), OpenAI-style
+- Where the Panacea-specific extensions (`anote_sources`, `anote_message_id`) show up in the response
+
+## Why this matters
+
+A huge amount of existing tooling — LangChain integrations, internal scripts, third-party agent frameworks — is written against the OpenAI SDK's shape (`client.chat.completions.create(...)`, `client.models.list()`). Rather than asking every integrator to learn a bespoke Panacea SDK, Panacea ships a drop-in client that speaks the same interface, so teams can adopt Panacea's private, document-grounded backend without rewriting their integration code.
+
+## Key Panacea files
+
+| File | Why it matters |
+|---|---|
+| `Panacea/backend/sdk/anoteai/openai_compat.py` | `AnoteOpenAI` client: `CompletionsClient`, `ModelsClient`, `DocumentsClient`, and the SSE stream parser |
+| `Panacea/backend/sdk/anoteai/core.py` | The underlying `PrivateChatbot` SDK class that the compat layer wraps |
+| `Panacea/backend/sdk/anoteai/handlers/private_handlers.py` | Request handling shared with the native SDK |
+| Server routes: `POST /v1/chat/completions`, `GET /v1/models`, `POST /v1/question-answer`, `POST /public/upload` | The OpenAI-shaped (and one Panacea-specific) endpoints the client calls |
+
+## How it works
+
+1. Instantiate the client exactly like the OpenAI SDK, but pointed at your Panacea backend:
+
+   ```python
+   from anoteai.openai_compat import AnoteOpenAI
+
+   client = AnoteOpenAI(
+       api_key="your-anote-api-key",       # or set ANOTE_API_KEY
+       base_url="http://localhost:5000",    # or https://api.anote.ai
+   )
+   ```
+
+2. For document-grounded Q&A, upload files first — `client.documents.upload(...)` posts multipart form data to `/public/upload` and returns a `chat_id`.
+3. Ask a question the same way you'd call the OpenAI SDK, passing the `chat_id` through `extra_body` so the server knows which documents to retrieve against:
+
+   ```python
+   upload_resp = client.documents.upload("path/to/report.pdf")
+   chat_id = upload_resp["chat_id"]
+
+   response = client.chat.completions.create(
+       model="gpt-4o",
+       messages=[{"role": "user", "content": "Summarise the key findings."}],
+       extra_body={"chat_id": chat_id},
+   )
+   print(response.choices[0].message.content)
+   print("Sources:", response.anote_sources)
+   ```
+
+4. The response is mapped into dataclasses that mirror the real OpenAI SDK (`ChatCompletion`, `Choice`, `Message`, `Usage`), plus two Panacea extensions: `anote_message_id` and `anote_sources` (the retrieved chunks/citations backing the answer).
+5. Pass `stream=True` to get a generator of `ChatCompletionChunk` objects parsed from `text/event-stream` SSE lines (`data: {...}` per token, terminated by `data: [DONE]`) — the same shape OpenAI's streaming client produces.
+6. `client.models.list()` calls `GET /v1/models` for model discovery, returning `Model`/`ModelList` objects just like the OpenAI SDK.
+
+## Run it locally
+
+From the workspace root (`anote/panacea`):
+
+```bash
+cd Panacea
+cp backend/.env.example backend/.env
+docker compose up --build
+```
+
+Install the client's one dependency and set your API key:
+
+```bash
+pip install requests
+export ANOTE_API_KEY=your_api_key_here   # macOS/Linux
+set ANOTE_API_KEY=your_api_key_here      # Windows cmd
+```
+
+### Minimal walkthrough
+
+```python
+from anoteai.openai_compat import AnoteOpenAI
+
+client = AnoteOpenAI(base_url="http://localhost:5000")
+
+# Plain chat, no documents:
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+)
+print(response.choices[0].message.content)
+
+# Streaming:
+for chunk in client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "Count to five."}],
+    stream=True,
+):
+    for choice in chunk.choices:
+        if choice.delta.content:
+            print(choice.delta.content, end="", flush=True)
+```
+
+## Notes for the cookbook
+
+This recipe is a good complement to recipe 03 — it's the same document Q&A/RAG capability, but exposed through an interface that existing OpenAI-SDK-based tooling can consume unmodified. Worth flagging to readers that `DocumentsClient.upload()`/`question_answer()` are Panacea-specific helpers layered on top of the OpenAI-compatible core, not part of the OpenAI spec itself.

--- a/packages/web/src/cookbook/recipes/08-panacea-billing-and-api-keys.md
+++ b/packages/web/src/cookbook/recipes/08-panacea-billing-and-api-keys.md
@@ -1,0 +1,83 @@
+# Panacea Billing, API Keys & Credit Metering
+
+This recipe explains how Panacea meters usage, authenticates API callers, and turns Stripe subscriptions into a spendable credit balance.
+
+## What you'll learn
+
+- The three ways a request can authenticate: JWT, session token, or long-lived API key
+- How credits are checked and deducted per request, and how usage is logged
+- How a Stripe subscription checkout flows through to a refreshed credit balance
+- How users generate, list, and revoke their own API keys
+- The abuse guardrails that gate new/changed subscriptions
+
+## Why this matters
+
+Panacea isn't just a RAG demo — it's a metered product with real subscription tiers. Every document upload, chat completion, or evaluation call costs credits, and credits are replenished by an active Stripe subscription. This recipe walks through the full loop: how a caller proves who they are, how that identity is priced, and how money (via Stripe) turns back into usable credits.
+
+## Key Panacea files
+
+| File | Why it matters |
+|---|---|
+| `Panacea/backend/database/db_auth.py` | `extractUserEmailFromRequest()` tries JWT → session token → API key in sequence; `user_has_credits()`, `api_key_user_has_credits()`, `deduct_credits_from_api_key_user()`; abuse guardrails in `verifyAuthForNewSubscriptipns()` |
+| `Panacea/backend/database/usage.py` | `log_api_usage()` writes one row per request to `api_usage`; `get_usage_summary()` / `get_usage_rows()` power usage reporting |
+| `Panacea/backend/api_endpoints/payments/handler.py` | `CreateCheckoutSessionHandler`, `CreatePortalSessionHandler`, `StripeWebhookHandler` |
+| `Panacea/backend/api_endpoints/generate_api_key/handler.py`, `get_api_keys/handler.py`, `delete_api_key/handler.py`, `refresh_credits/handler.py` | Mint, list, revoke API keys; manually refresh credits |
+| `Panacea/backend/stripe_config/portal_config.py` | Per-tier Stripe Billing Portal configuration |
+
+## How it works
+
+1. **Authenticate.** Every protected route calls `extractUserEmailFromRequest(request)`, which reads the `Authorization: Bearer <token>` header and tries, in order: decode as a JWT, look up as a session token (`user_email_for_session_token`), then look up as an API key (`user_email_for_api_key`). Whichever succeeds first resolves the caller's email.
+2. **Check credits.** Before serving a request, the backend calls `user_has_credits(user_email)` (JWT/session callers) or `api_key_user_has_credits(api_key)` (API-key callers) to confirm the user's `credits` column in `users` is at least 1.
+3. **Deduct and log.** On completion, `deduct_credits_from_api_key_user()` decrements the balance and `log_api_usage()` inserts a row into `api_usage` with the endpoint, model, token counts, and credits spent — this is what powers `GET /v1/usage` and `GET /v1/account`.
+4. **Upgrade via Stripe.** The frontend calls `POST /createCheckoutSession`, which hits `CreateCheckoutSessionHandler`: it resolves the user, maps the requested `product_hash` to a Stripe price ID, and creates a `stripe.checkout.Session` in `subscription` mode (optionally applying a 30-day free trial code).
+5. **Webhook completes the loop.** Stripe calls back `POST /stripeWebhook` on `checkout.session.completed`; `StripeWebhookHandler` records the new subscription via `add_subscription()` and calls `refresh_credits(user_email)` to top up the user's balance. `customer.subscription.updated` (cancellation) and `.deleted` events are handled symmetrically.
+6. **Manage the subscription.** `POST /createPortalSession` (`CreatePortalSessionHandler`) opens a Stripe Billing Portal session scoped to the user's current tier via `config_for_payment_tiers()`, so upgrades/downgrades/cancellations happen through Stripe's hosted UI.
+7. **API keys.** `POST /generateAPIKey` requires at least 1 credit and calls `generate_api_key()`; `GET /getAPIKeys` and `POST /deleteAPIKey` list/revoke keys, each tracked with a `last_used` timestamp (`touch_api_key_last_used`).
+
+### Abuse guardrails
+
+`verifyAuthForNewSubscriptipns()` in `db_auth.py` caps new subscriptions per tier per day (e.g. 25/day for Premium, 5/day for Enterprise), emails an internal alert at defined thresholds (5, 10, 50, 100, 200, 500 new subscriptions/day), and blocks a user from changing plans more than once in a rolling month.
+
+## Run it locally
+
+From the workspace root (`anote/panacea`):
+
+```bash
+cd Panacea
+cp backend/.env.example backend/.env
+docker compose up --build
+```
+
+Set these in `backend/.env` to exercise the billing flow:
+
+```bash
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_PUBLIC_KEY=pk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+FRONTEND_URL=http://localhost:3000
+JWT_SECRET_KEY=some-dev-secret
+```
+
+Forward Stripe webhooks to your local backend with the Stripe CLI:
+
+```bash
+stripe listen --forward-to localhost:5000/stripeWebhook
+```
+
+### Try it
+
+```bash
+# Generate an API key (requires an authenticated JWT/session, and >=1 credit)
+curl -X POST http://localhost:5000/generateAPIKey \
+  -H "Authorization: Bearer <jwt_or_session_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my first key"}'
+
+# Check usage with the new API key
+curl http://localhost:5000/v1/usage \
+  -H "Authorization: Bearer <api_key>"
+```
+
+## Notes for the cookbook
+
+Pair this with recipe 07 (OpenAI-Compatible API Gateway) — the same API keys generated here are what authenticate `AnoteOpenAI` calls. Worth flagging the `verifyAuthForNewSubscriptipns` typo in the function name as a known quirk if a reader goes looking for it in the code.

--- a/packages/web/src/cookbook/recipes/09-panacea-mcp-tool-server.md
+++ b/packages/web/src/cookbook/recipes/09-panacea-mcp-tool-server.md
@@ -1,0 +1,80 @@
+# Panacea MCP Tool Server
+
+This recipe explains how Panacea exposes its document/chat primitives as standard [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) tools, so any MCP-compatible client (Claude Desktop, other MCP hosts) can use Panacea's retrieval and chat-history capabilities directly.
+
+## What you'll learn
+
+- The difference between this MCP surface and the internal agent/tool-registration architecture from recipe 04
+- Which document and chat operations are exposed as MCP tools
+- How document ingestion stays non-blocking via a Ray remote task
+- Why the raw SQL passthrough tool is a security consideration worth calling out
+
+## Why this matters
+
+Recipe 04 covers how Panacea's *internal* orchestrator registers tools for its own agents to call. This is a different integration surface: it packages the same underlying document/chat functions as **external, standardized MCP tools** that any MCP client can invoke — no Panacea-specific SDK or API contract required, just the MCP protocol.
+
+## Key Panacea files
+
+| File | Why it matters |
+|---|---|
+| `Panacea/backend/mcp/mcp_server.py` | `FastMCP("Document Agent Server")` — defines all nine MCP tools |
+| `Panacea/backend/api_endpoints/financeGPT/chatbot_endpoints.py` | The underlying DB-facing functions each MCP tool wraps (`get_relevant_chunks`, `add_document_to_db`, `chunk_document`, etc.) |
+| `Panacea/backend/database/db.py` | `get_db_connection` — used directly by the `execute_database_query` tool |
+
+## How it works
+
+1. `mcp_server.py` initializes Ray (`ray.init(...)`) and a `FastMCP` server instance named `"Document Agent Server"`.
+2. Each function decorated with `@mcp.tool()` wraps an existing Panacea function and returns a plain-text result or error string — the shape an LLM tool call expects back:
+   - `retrieve_relevant_chunks(query, chat_id, user_email, k=2)` — semantic search over a chat's documents via `get_relevant_chunks`
+   - `ingest_document(text, document_name, chat_id, chunk_size=1000)` — registers a document via `add_document_to_db`
+   - `list_documents(chat_id, user_email)` / `delete_document(doc_id, user_email)` — document management
+   - `add_message` / `get_chat_history` — chat history read/write
+   - `add_sources_to_message` — attach citations to a stored message
+   - `extract_text_from_url(url)` — fetch and return text content from a URL
+   - `execute_database_query(query, params)` — raw SQL passthrough (see security note below)
+3. `ingest_document` doesn't block on chunking — it calls `chunk_document.remote(text, chunk_size, doc_id)`, a Ray remote task, so large documents are processed asynchronously while the tool call returns immediately.
+4. Running `python backend/mcp/mcp_server.py` starts `mcp.run()`, which serves these tools over MCP's stdio transport — ready for an MCP client to launch and connect to.
+5. An MCP client (e.g. Claude Desktop) configured to launch this script gets access to all nine tools automatically, without writing any Panacea-specific integration code.
+
+### Security note
+
+`execute_database_query` executes an arbitrary SQL string against the production connection with no allow-list or read-only restriction — `SELECT` queries return rows as JSON, anything else commits and returns the affected-row count. Treat this as least-privilege territory: if you expose this server to an MCP client you don't fully trust, either remove this tool or scope its DB user to read-only access on non-sensitive tables.
+
+## Run it locally
+
+From the workspace root (`anote/panacea`):
+
+```bash
+cd Panacea
+cp backend/.env.example backend/.env
+docker compose up --build   # brings up MySQL, Redis, Tika, and the backend
+```
+
+The MCP server needs `fastmcp` (not currently pinned in `backend/requirements.txt` — install it separately) and `ray>=2.9.0` (already in `backend/requirements.txt`):
+
+```bash
+pip install fastmcp
+cd Panacea/backend
+python mcp/mcp_server.py
+```
+
+### Connect an MCP client
+
+Point an MCP-compatible client at the script, e.g. in Claude Desktop's `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "panacea-documents": {
+      "command": "python",
+      "args": ["/absolute/path/to/Panacea/backend/mcp/mcp_server.py"]
+    }
+  }
+}
+```
+
+Restart the client, and the nine tools above become available to invoke from chat.
+
+## Notes for the cookbook
+
+Good follow-up to recipe 04 — contrast internal tool registration (`register_tool()` inside the orchestrator) with this external MCP surface. Also worth noting as a gap for readers: `fastmcp` isn't yet listed in `backend/requirements.txt`, so it needs a manual install until that's fixed upstream.

--- a/packages/web/src/cookbook/recipes/10-panacea-messaging-bots.md
+++ b/packages/web/src/cookbook/recipes/10-panacea-messaging-bots.md
@@ -1,0 +1,78 @@
+# Panacea Multi-Channel Messaging Bots
+
+This recipe explains Panacea's chat-ops style integrations: standalone Slack, SMS, and WhatsApp bots that let users ask coding questions from the messaging apps they already use.
+
+## What you'll learn
+
+- The shared design pattern across all three bots: receive → call an LLM → trim to the channel's character limit → reply
+- How the Slack bot handles threading and edits a "thinking…" placeholder in place
+- How the SMS/WhatsApp bots reply synchronously using Twilio's TwiML
+- A current architectural gap worth knowing about before extending these bots
+
+## Why this matters
+
+Not every user wants to open a web UI or IDE to ask a question — chat-ops style integrations meet people where they already are. Each bot is a small, independently deployable Flask service, so a team can run just the channels they need (e.g. Slack only) without standing up the rest of Panacea's stack.
+
+## Key Panacea files
+
+| File | Why it matters |
+|---|---|
+| `Panacea/packages/bots/slack/app.py` | Slack Bolt app; supports Socket Mode or HTTP webhook; threaded "thinking…" placeholder updated in place |
+| `Panacea/packages/bots/sms/app.py` | Twilio SMS webhook handler (`MessagingResponse`/TwiML) |
+| `Panacea/packages/bots/whatsapp/app.py` | Twilio WhatsApp sandbox webhook handler |
+| `Panacea/packages/bots/{slack,sms,whatsapp}/.env.example` | Required credentials per channel |
+
+## How it works
+
+1. **Slack** (`slack/app.py`): listens for `app_mention` events. `extract_query()` strips the `<@BOT_ID>` mention out of the message text. It immediately posts a `_Anote is thinking…_` placeholder message, then runs the LLM call on a background thread and either edits that placeholder in place via `client.chat_update(...)` or, if the placeholder post failed, sends a fresh threaded reply.
+2. **SMS** (`sms/app.py`): Twilio POSTs each inbound text to `/sms` as form data (`Body`, `From`). The handler calls the LLM synchronously and returns a `MessagingResponse` (TwiML) with the reply — Twilio delivers it as a follow-up text.
+3. **WhatsApp** (`whatsapp/app.py`): same TwiML pattern as SMS, wired to Twilio's WhatsApp sandbox webhook instead of a phone number.
+4. All three call the **Anthropic API directly** (`anthropic.Anthropic(...).messages.create(...)`) with a shared system prompt describing Anote as a coding assistant — they do not currently proxy through Panacea's own backend, so they don't get RAG/document grounding, credit metering, or multi-agent orchestration from recipes 03/04/08.
+5. Responses are trimmed to each channel's limit before sending: Slack 2900 characters, SMS/WhatsApp 1600 characters, each with a truncation notice appended if cut.
+
+### Architectural gap to know about
+
+Because these bots call Anthropic directly instead of routing through Panacea's backend, a Slack/SMS/WhatsApp user can't currently ask questions grounded in documents they've uploaded to Panacea, and their usage isn't metered through the credit system in recipe 08. If you want channel parity with the web UI, the natural next step is swapping the direct `anthropic_client.messages.create(...)` call for a request to Panacea's own `/v1/chat/completions` (recipe 07's OpenAI-compatible gateway) so these bots inherit RAG, orchestration, and billing for free.
+
+## Run it locally
+
+Each bot is independent — install and run only the ones you need.
+
+### Slack
+
+```bash
+cd Panacea/packages/bots/slack
+pip install -r requirements.txt
+cp .env.example .env   # fill in SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, ANTHROPIC_API_KEY
+python app.py
+```
+
+Set `SLACK_APP_TOKEN` in `.env` to run in Socket Mode (no public URL needed); otherwise it serves HTTP on `PORT` (default 3000) and expects Slack's Events API webhook pointed at `POST /slack/events`.
+
+### SMS
+
+```bash
+cd Panacea/packages/bots/sms
+pip install -r requirements.txt
+cp .env.example .env   # fill in ANTHROPIC_API_KEY
+python app.py
+```
+
+Configure your Twilio phone number's SMS webhook to `POST https://<your-host>/sms` (default port 3001).
+
+### WhatsApp
+
+```bash
+cd Panacea/packages/bots/whatsapp
+pip install -r requirements.txt
+cp .env.example .env   # fill in ANTHROPIC_API_KEY
+python app.py
+```
+
+Configure your Twilio WhatsApp sandbox webhook to point at `POST /whatsapp` on this service.
+
+Each bot also exposes `GET /health` for a quick liveness check.
+
+## Notes for the cookbook
+
+This is a good "extend Panacea" recipe: readers can see the direct-to-Anthropic version working in minutes, then follow the architectural-gap note above to wire it through Panacea's backend instead for grounded, metered answers.

--- a/packages/web/src/landing_page/Navbar.js
+++ b/packages/web/src/landing_page/Navbar.js
@@ -30,6 +30,9 @@ function Navbar() {
               {link.label}
             </a>
           ))}
+          <Link to="/cookbook" className="hover:text-gray-900 dark:hover:text-white">
+            Cookbook
+          </Link>
         </div>
 
         <div className="hidden md:flex items-center gap-3">
@@ -80,6 +83,13 @@ function Navbar() {
               {link.label}
             </a>
           ))}
+          <Link
+            to="/cookbook"
+            onClick={() => setOpen(false)}
+            className="py-1 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
+          >
+            Cookbook
+          </Link>
           <div className="flex items-center gap-3 pt-3 border-t border-gray-200 dark:border-gray-700">
             <button
               onClick={toggle}

--- a/packages/web/src/pages/CookbookPage.tsx
+++ b/packages/web/src/pages/CookbookPage.tsx
@@ -1,0 +1,98 @@
+import { Link, useNavigate, useParams } from "react-router-dom";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import RocketLogo from "../components/RocketLogo";
+import { useTheme } from "../App";
+import { COOKBOOK_RECIPES, getRecipeContent } from "../cookbook/manifest";
+
+const GROUPS: { id: "platform"; label: string }[] = [
+  { id: "platform", label: "Panacea platform" },
+];
+
+export default function CookbookPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const nav = useNavigate();
+  const { dark, toggle } = useTheme();
+
+  const active = COOKBOOK_RECIPES.find((r) => r.slug === slug) || COOKBOOK_RECIPES[0];
+  const content = getRecipeContent(active.slug);
+
+  return (
+    <div className="flex h-screen bg-white dark:bg-[#212121] text-gray-900 dark:text-white">
+      {/* Sidebar */}
+      <aside className="w-72 flex-shrink-0 bg-[#F7F7F8] dark:bg-[#171717] flex flex-col">
+        <Link to="/" className="p-3 flex items-center gap-2 hover:bg-gray-200 dark:hover:bg-[#2F2F2F] rounded-lg m-1">
+          <RocketLogo className="w-7 h-7 flex-shrink-0" />
+          <span className="font-semibold text-sm truncate">Cookbook</span>
+        </Link>
+
+        <div className="flex-1 overflow-y-auto px-2 pb-3 space-y-4">
+          {GROUPS.map((group) => (
+            <div key={group.id}>
+              <p className="px-3 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                {group.label}
+              </p>
+              <div className="space-y-0.5">
+                {COOKBOOK_RECIPES.filter((r) => r.group === group.id).map((r) => (
+                  <button
+                    key={r.slug}
+                    onClick={() => nav(`/cookbook/${r.slug}`)}
+                    className={`w-full text-left px-3 py-2 rounded-lg text-sm flex items-center justify-between gap-2 transition-colors ${
+                      r.slug === active.slug
+                        ? "bg-gray-200 dark:bg-[#2F2F2F]"
+                        : "hover:bg-gray-200 dark:hover:bg-[#2F2F2F]"
+                    }`}
+                  >
+                    <span className="truncate">{r.name}</span>
+                    <span
+                      className={`flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded-full border ${
+                        r.runnable
+                          ? "border-gray-400 dark:border-gray-500 text-gray-600 dark:text-gray-300"
+                          : "border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500"
+                      }`}
+                    >
+                      {r.runnable ? "Run" : "Guide"}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="p-3 border-t border-gray-200 dark:border-gray-700">
+          <Link
+            to="/"
+            className="block px-3 py-2 rounded-lg text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-[#2F2F2F]"
+          >
+            &larr; Back to Panacea
+          </Link>
+        </div>
+      </aside>
+
+      {/* Main */}
+      <div className="flex-1 flex flex-col min-w-0">
+        <header className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
+            Cookbook / {active.name}
+          </span>
+          <button
+            onClick={toggle}
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-[#2F2F2F] text-gray-500 dark:text-gray-400"
+            aria-label="Toggle dark mode"
+          >
+            {dark ? "☀️" : "🌙"}
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-3xl mx-auto px-4 py-8">
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -5,5 +5,5 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
## Summary
- Adds a `/cookbook` route + page that lists the Panacea platform guides (recipes 03-10 from the [Cookbook](https://github.com/anote-ai/Cookbook) repo) and renders their real README content, styled to match the existing chat UI (RocketLogo, sidebar layout, monochrome light/dark palette)
- Links to it from the landing page navbar
- Installs `@tailwindcss/typography` and wires it into `tailwind.config.js` — it was missing, so markdown (both here and in `ChatPage`'s assistant messages) rendered with no heading/list/table/code hierarchy

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified in a real browser (Playwright): landing page nav link → `/cookbook` → browse recipes → dark mode toggle, zero console errors
- [x] Confirmed markdown now renders with proper typography in both themes