### PR TITLE
feat: try-it-now demo — 3 sample documents, source citations, 5 free questions, no sign-up (closes #200)

### DIFF
--- a/packages/backend/api_endpoints/demo/handler.py
+++ b/packages/backend/api_endpoints/demo/handler.py
@@ -1,0 +1,81 @@
+"""Public no-auth demo endpoints: pre-loaded sample documents + limited Q&A (issue #200)."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from services.demo import DEMO_DOCS, answer_demo_question, ensure_indexed
+
+demo_bp = Blueprint("demo", __name__, url_prefix="/api/demo")
+
+QUESTION_LIMIT = 5
+
+# Per-client question counts, keyed by IP. In-memory by design: the demo gate
+# is a soft conversion nudge, not a security boundary.
+_question_counts: dict[str, int] = {}
+
+_DEMO_DOC_IDS = {doc["id"] for doc in DEMO_DOCS}
+
+
+def _client_key() -> str:
+    forwarded = request.headers.get("X-Forwarded-For", "")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.remote_addr or "unknown"
+
+
+@demo_bp.get("/documents")
+def list_demo_documents() -> tuple:  # type: ignore[type-arg]
+    """The pre-loaded sample documents, plus the caller's remaining free questions."""
+    remaining = max(0, QUESTION_LIMIT - _question_counts.get(_client_key(), 0))
+    docs = [
+        {
+            "id": doc["id"],
+            "name": doc["name"],
+            "category": doc["category"],
+            "suggestedQuestions": doc["suggestedQuestions"],
+        }
+        for doc in DEMO_DOCS
+    ]
+    return jsonify({"documents": docs, "questionLimit": QUESTION_LIMIT, "remaining": remaining}), 200
+
+
+@demo_bp.post("/ask")
+def ask_demo() -> tuple:  # type: ignore[type-arg]
+    data = request.get_json(silent=True) or {}
+    question = (data.get("question") or "").strip()
+    if not question:
+        return jsonify({"error": "Question is required"}), 400
+    if len(question) > 500:
+        return jsonify({"error": "Question is too long (500 characters max)"}), 400
+
+    doc_id = data.get("docId") or None
+    if doc_id is not None and doc_id not in _DEMO_DOC_IDS:
+        return jsonify({"error": "Unknown demo document"}), 404
+
+    key = _client_key()
+    used = _question_counts.get(key, 0)
+    if used >= QUESTION_LIMIT:
+        return (
+            jsonify({
+                "error": "Free demo limit reached — sign up to keep asking questions.",
+                "signupRequired": True,
+                "remaining": 0,
+            }),
+            429,
+        )
+
+    try:
+        ensure_indexed()
+        result = answer_demo_question(question, doc_id)
+    except Exception:
+        return jsonify({"error": "Internal server error"}), 500
+
+    _question_counts[key] = used + 1
+    return (
+        jsonify({
+            "answer": result["answer"],
+            "sources": result["sources"],
+            "remaining": QUESTION_LIMIT - (used + 1),
+        }),
+        200,
+    )

--- a/packages/backend/app.py
+++ b/packages/backend/app.py
@@ -9,6 +9,7 @@ from flask_jwt_extended import JWTManager
 
 from api_endpoints.auth.handler import auth_bp, google_oauth_callback
 from api_endpoints.chat.handler import chat_bp
+from api_endpoints.demo.handler import demo_bp
 from api_endpoints.documents.handler import documents_bp
 from api_endpoints.folders.handler import folders_bp
 from api_endpoints.payments.handler import payments_bp
@@ -45,6 +46,7 @@ def create_app(config: dict | None = None) -> Flask:
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(chat_bp)
+    app.register_blueprint(demo_bp)
     app.register_blueprint(documents_bp)
     app.register_blueprint(folders_bp)
     app.register_blueprint(search_bp)

--- a/packages/backend/demo_data/annual_report.md
+++ b/packages/backend/demo_data/annual_report.md
@@ -1,0 +1,56 @@
+# Meridian Robotics, Inc. — 2025 Annual Report
+
+*This is a fictional sample document provided for demonstration purposes. Meridian Robotics, Inc. is not a real company.*
+
+## Letter to Shareholders
+
+2025 was a defining year for Meridian Robotics. Revenue grew 42% to $847 million, driven by record demand for our warehouse automation platform and the successful launch of the Atlas Mk III autonomous picking arm. We ended the year with $312 million in cash and equivalents, no long-term debt, and our first full year of positive free cash flow.
+
+## Financial Highlights
+
+| Metric | 2025 | 2024 | Change |
+|---|---|---|---|
+| Total revenue | $847M | $596M | +42% |
+| Gross margin | 38.4% | 33.1% | +5.3 pts |
+| Operating income (loss) | $41M | $(63)M | — |
+| Net income (loss) | $28M | $(71)M | — |
+| Free cash flow | $54M | $(38)M | — |
+| Cash and equivalents | $312M | $268M | +16% |
+| Full-time employees | 2,140 | 1,730 | +24% |
+
+Revenue by segment: Warehouse Automation contributed $612 million (72% of total revenue), Manufacturing Robotics $178 million (21%), and Service & Software $57 million (7%). Service & Software is our fastest-growing segment at 89% year-over-year growth, and carries a 71% gross margin compared to 34% for hardware.
+
+## Business Overview
+
+Meridian designs, manufactures, and services autonomous robotic systems for warehouse logistics and light manufacturing. Our flagship products are:
+
+- **Atlas Mk III** — a vision-guided autonomous picking arm capable of 1,100 picks per hour with a 99.2% grasp success rate across 40,000+ SKU types.
+- **Pathfinder AMR fleet** — autonomous mobile robots for pallet and tote transport, with 4,800 units deployed across 61 customer sites.
+- **MeridianOS** — our fleet-orchestration software layer, sold by subscription, now covering 92% of deployed units.
+
+During 2025 we deployed our first international installations in Rotterdam and Nagoya, and grew our installed base from 39 to 61 active customer sites. Our largest customer accounted for 18% of revenue in 2025, down from 26% in 2024.
+
+## Risk Factors
+
+Investors should consider the following principal risks:
+
+1. **Customer concentration.** Our top three customers together represented 41% of 2025 revenue. The loss of, or a significant reduction in orders from, any of these customers would materially harm our results.
+2. **Supply chain dependency.** We source precision harmonic drives from a single supplier in Japan. A disruption at this supplier could delay production by up to six months. We carry approximately 90 days of buffer inventory.
+3. **Competition.** The warehouse automation market is intensely competitive. Several competitors have substantially greater financial resources, and price competition reduced our average selling price by roughly 7% during 2025.
+4. **Technology execution.** Our roadmap depends on continued improvement of our grasp-planning AI models. Failure to maintain our technical lead could erode our win rate, which was 58% of competitive bids in 2025.
+5. **International expansion.** Operating in the EU and Japan exposes us to currency fluctuations, local safety-certification regimes, and longer sales cycles that averaged 9.5 months for international deals versus 5.8 months domestically.
+6. **Labor relations.** Some prospective customers face internal labor opposition to automation projects, which can delay or cancel deployments.
+
+## Management's Discussion and Analysis
+
+Gross margin improved 5.3 percentage points, primarily from a higher software mix and a 12% reduction in per-unit manufacturing cost of the Atlas line following the opening of our expanded Reno facility. Operating expenses grew 21%, slower than revenue, reflecting operating leverage: R&D spend was $138 million (16% of revenue) and sales & marketing $97 million (11% of revenue).
+
+We expect 2026 revenue of $1.05–$1.12 billion, implying 24–32% growth, with continued gross-margin expansion toward 41% as the software mix increases. Capital expenditures are planned at $85 million, principally for the second phase of the Reno facility.
+
+## Backlog and Bookings
+
+Year-end contracted backlog stood at $1.34 billion, up 51% from $886 million a year earlier. Approximately 62% of backlog is expected to convert to revenue within 24 months. Remaining performance obligations for the software segment were $203 million, with an average subscription term of 3.4 years.
+
+## Dividend Policy
+
+We have never declared or paid cash dividends and do not intend to for the foreseeable future; we retain all earnings to fund growth.

--- a/packages/backend/demo_data/employment_contract.md
+++ b/packages/backend/demo_data/employment_contract.md
@@ -1,0 +1,64 @@
+# Employment Agreement
+
+*This is a fictional sample document provided for demonstration purposes only. It is not legal advice and the parties named are not real.*
+
+This Employment Agreement (the "Agreement") is entered into as of **March 1, 2026** (the "Effective Date") by and between **Northwind Analytics, LLC**, a Delaware limited liability company (the "Company"), and **Jordan Ellis** (the "Employee").
+
+## 1. Position and Duties
+
+The Company employs the Employee as **Senior Data Analyst**, reporting to the Director of Research. The Employee shall devote their full business time and best efforts to the performance of their duties and shall not engage in outside employment that conflicts with those duties without prior written consent of the Company.
+
+## 2. Term
+
+Employment under this Agreement is **at-will**. Either party may terminate the employment relationship at any time, with or without cause, subject to the notice provisions of Section 8.
+
+## 3. Compensation
+
+3.1 **Base Salary.** The Company shall pay the Employee an annual base salary of **$96,000**, payable in accordance with the Company's standard payroll schedule (semi-monthly).
+
+3.2 **Annual Bonus.** The Employee is eligible for a discretionary annual performance bonus with a target of **10% of base salary**, based on individual and Company performance, payable no later than March 15 of the following year. The Employee must be employed on the payment date to receive the bonus.
+
+3.3 **Equity.** Subject to approval by the Company's Board, the Employee will be granted **8,000 profits-interest units**, vesting over four years: 25% on the first anniversary of the Effective Date, and the remainder in equal monthly installments over the following 36 months.
+
+## 4. Benefits
+
+The Employee is entitled to participate in the Company's benefit plans on the same basis as similarly situated employees, including: medical, dental, and vision insurance (Company pays 80% of premiums); a 401(k) plan with a Company match of 100% of the first 4% of salary deferred; and a $1,500 annual professional development allowance.
+
+## 5. Paid Time Off
+
+The Employee accrues **20 days of paid vacation per year** (accruing semi-monthly), plus 8 Company holidays and 5 days of paid sick leave. Unused vacation carries over up to a cap of 30 days; accrual pauses at the cap. Unused sick leave does not carry over and is not paid out on termination.
+
+## 6. Confidentiality
+
+The Employee shall not, during or after employment, disclose or use any Confidential Information of the Company except as required to perform their duties. "Confidential Information" includes non-public business plans, customer lists, financial data, models, source code, and research methods. This obligation survives termination of employment indefinitely.
+
+## 7. Intellectual Property
+
+All inventions, works of authorship, and developments conceived by the Employee within the scope of employment or using Company resources are the sole property of the Company ("Company Inventions"). The Employee assigns all right, title, and interest in Company Inventions to the Company. Inventions made entirely on the Employee's own time, without Company resources, and unrelated to the Company's business are excluded (listed, if any, in Exhibit A).
+
+## 8. Termination and Notice
+
+8.1 **Resignation.** The Employee agrees to provide at least **two (2) weeks' written notice** of resignation.
+
+8.2 **Termination by the Company.** The Company may terminate the Employee at any time. If the Company terminates the Employee **without Cause** after six months of employment, the Employee is entitled to severance equal to **four (4) weeks of base salary**, conditioned on signing a general release of claims.
+
+8.3 **Cause.** "Cause" means: (a) material breach of this Agreement not cured within 15 days of written notice; (b) willful misconduct or gross negligence; (c) conviction of a felony; or (d) repeated failure to perform lawful duties after written warning.
+
+8.4 **Final Pay.** Upon any termination, the Company shall pay all earned but unpaid salary and accrued unused vacation in accordance with applicable law.
+
+## 9. Restrictive Covenants
+
+9.1 **Non-Solicitation.** For **twelve (12) months** following termination, the Employee shall not solicit any employee of the Company to leave, or solicit any customer with whom the Employee worked during the final 12 months of employment for a competing business.
+
+9.2 **Non-Competition.** For **six (6) months** following termination, the Employee shall not perform substantially similar services for a direct competitor of the Company within the United States, to the extent enforceable under applicable law. This Section 9.2 does not apply if the Company terminates the Employee without Cause.
+
+## 10. Dispute Resolution
+
+Any dispute arising out of this Agreement shall be resolved by **binding arbitration** in Wilmington, Delaware, administered under the rules of the American Arbitration Association, except that either party may seek injunctive relief in court for breaches of Sections 6, 7, or 9. Each party bears its own attorneys' fees except where a statute provides otherwise.
+
+## 11. General
+
+This Agreement is governed by the laws of the State of Delaware. It constitutes the entire agreement of the parties regarding its subject matter and may be amended only in a writing signed by both parties. If any provision is held unenforceable, the remainder continues in effect.
+
+**Northwind Analytics, LLC** — By: Casey Morgan, Managing Member
+**Employee** — Jordan Ellis

--- a/packages/backend/demo_data/llm_research_paper.md
+++ b/packages/backend/demo_data/llm_research_paper.md
@@ -1,0 +1,52 @@
+# Retrieval Quality, Not Model Scale, Dominates Document Q&A Accuracy: An Empirical Study
+
+*This is an original sample document written for demonstration purposes.*
+
+**Authors:** Sample Research Group
+**Status:** Working paper (demonstration copy)
+
+## Abstract
+
+We study the relative contribution of retrieval quality and language-model scale to end-to-end accuracy in retrieval-augmented document question answering (RAG). Across 4,800 question–document pairs spanning financial filings, contracts, and technical manuals, we find that improving the retriever explains 2.9× more variance in answer correctness than upgrading the generator model by one capability tier. Chunking strategy alone shifts accuracy by up to 14 percentage points. We conclude with practical recommendations: invest first in retrieval (chunking, query expansion, re-ranking), ground every answer in citations, and expose confidence to end users.
+
+## 1. Introduction
+
+Retrieval-augmented generation has become the default architecture for question answering over private document collections. A persistent practitioner question is where marginal effort should go: a larger generator model, or a better retrieval pipeline? Anecdotal reports conflict, and public benchmarks typically hold the retriever fixed.
+
+We isolate the two factors experimentally. Our study varies (a) generator capability across three tiers, (b) chunk size and overlap, (c) query expansion, and (d) cross-encoder re-ranking, measuring exact-answer accuracy judged by a held-out grader with 96% human agreement.
+
+## 2. Method
+
+**Corpus.** 120 documents: 40 annual reports (mean 48 pages), 40 commercial contracts (mean 22 pages), 40 technical manuals (mean 65 pages).
+
+**Questions.** 4,800 questions written by domain annotators, split into extractive (61%), aggregative (27%), and inferential (12%) types. Each question has a gold answer span verified by two annotators.
+
+**Conditions.** Chunk sizes of 400, 1,000, and 2,000 characters with 0%, 10%, and 25% overlap; top-k retrieval with k ∈ {3, 5, 10}; optional LLM query expansion (two paraphrases); optional cross-encoder re-ranking of the top 20 candidates.
+
+## 3. Results
+
+**Retrieval dominates.** Moving from the worst to the best retrieval configuration improved end-to-end accuracy from 61.2% to 83.7% (+22.5 points) with the generator fixed. Upgrading the generator one tier with retrieval fixed improved accuracy by 7.8 points on average.
+
+**Chunking matters more than expected.** 1,000-character chunks with 10% overlap outperformed 2,000-character chunks by 9–14 points on extractive questions. Long chunks dilute the relevant span within the retrieved context.
+
+**Query expansion helps vocabulary mismatch.** Expansion added 4.1 points overall but 11.3 points on the subset where the question shared fewer than two content words with the gold passage.
+
+**Re-ranking is the best single addition.** Cross-encoder re-ranking of top-20 candidates into a final top-5 added 6.9 points at roughly 90 ms of added latency.
+
+**Failure modes.** Of remaining errors, 44% were retrieval misses (gold passage absent from context), 31% were synthesis errors over correct context, 18% were table-structure misreads, and 7% were grader disagreements. Notably, when the gold passage was present in the top-3 retrieved chunks, generator accuracy exceeded 94% across all model tiers.
+
+## 4. Practical Recommendations
+
+1. **Fix retrieval first.** Until the gold passage reliably appears in retrieved context, generator upgrades buy little.
+2. **Prefer ~1,000-character chunks with modest overlap** for mixed corpora.
+3. **Show citations.** Because 44% of failures are silent retrieval misses, exposing the retrieved source text lets users detect unanswerable questions immediately.
+4. **Expose confidence.** Retrieval similarity scores correlate (ρ = 0.62) with answer correctness and are cheap to surface.
+5. **Treat tables separately.** Structure-aware extraction for tables addresses the second-largest error class.
+
+## 5. Limitations
+
+Our corpus is English-only, and our grader, while highly agreeing with humans, may share failure modes with the graded models. Scanned documents without a text layer were excluded; OCR quality is a separate and significant factor in production systems.
+
+## 6. Conclusion
+
+In document Q&A, retrieval quality is the dominant lever on accuracy. Teams should benchmark their retrieval pipeline before paying for larger generators, and should treat citations and confidence display as core product features rather than optional extras.

--- a/packages/backend/services/demo.py
+++ b/packages/backend/services/demo.py
@@ -1,0 +1,153 @@
+"""Public demo — pre-loaded sample documents, no auth required (issue #200)."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from services.rag import _chunk_text
+
+DEMO_DIR = Path(__file__).resolve().parent.parent / "demo_data"
+_COLLECTION = "demo_documents"
+
+DEMO_DOCS: list[dict] = [
+    {
+        "id": "demo-annual-report",
+        "name": "Meridian Robotics 2025 Annual Report",
+        "category": "Financial",
+        "file": "annual_report.md",
+        "suggestedQuestions": [
+            "What are the main risk factors?",
+            "How much cash does the company have?",
+            "How fast is the software segment growing?",
+        ],
+    },
+    {
+        "id": "demo-llm-paper",
+        "name": "Research Paper: Retrieval Quality in Document Q&A",
+        "category": "Academic",
+        "file": "llm_research_paper.md",
+        "suggestedQuestions": [
+            "What matters more, retrieval or model scale?",
+            "What chunk size worked best?",
+            "What were the main failure modes?",
+        ],
+    },
+    {
+        "id": "demo-employment-contract",
+        "name": "Sample Employment Agreement",
+        "category": "Legal",
+        "file": "employment_contract.md",
+        "suggestedQuestions": [
+            "How much notice do I have to give to resign?",
+            "What severance is offered?",
+            "Is there a non-compete clause?",
+        ],
+    },
+]
+
+_indexed = False
+_answer_cache: dict[tuple[str, str], dict] = {}
+
+
+def _get_collection():
+    import chromadb
+    from chromadb.utils import embedding_functions
+
+    client = chromadb.PersistentClient(path=os.environ.get("CHROMA_PERSIST_DIR", "./chroma_db"))
+    ef = embedding_functions.DefaultEmbeddingFunction()
+    return client.get_or_create_collection(
+        _COLLECTION, embedding_function=ef  # type: ignore[arg-type]
+    )
+
+
+def ensure_indexed() -> None:
+    """Index the bundled sample documents once per process (idempotent)."""
+    global _indexed
+    if _indexed:
+        return
+    try:
+        collection = _get_collection()
+        for doc in DEMO_DOCS:
+            existing = collection.get(where={"doc_id": doc["id"]}, limit=1)
+            if existing.get("ids"):
+                continue
+            text = (DEMO_DIR / doc["file"]).read_text(encoding="utf-8")
+            chunks = _chunk_text(text)
+            collection.add(
+                documents=chunks,
+                ids=[f"{doc['id']}-{i}" for i in range(len(chunks))],
+                metadatas=[{"doc_id": doc["id"], "doc_name": doc["name"]}] * len(chunks),
+            )
+        _indexed = True
+    except Exception:
+        pass
+
+
+def retrieve_demo_chunks(question: str, doc_id: str | None = None, top_k: int = 4) -> list[dict]:
+    """Return the most relevant sample-document chunks with citation metadata."""
+    try:
+        collection = _get_collection()
+        where = {"doc_id": doc_id} if doc_id else None
+        results = collection.query(
+            query_texts=[question],
+            n_results=top_k,
+            where=where,  # type: ignore[arg-type]
+            include=["documents", "metadatas", "distances"],  # type: ignore[list-item]
+        )
+        docs = (results.get("documents") or [[]])[0]
+        metas = (results.get("metadatas") or [[]])[0]
+        dists = (results.get("distances") or [[]])[0]
+        sources = []
+        for chunk, meta, dist in zip(docs, metas, dists):
+            sources.append({
+                "chunk": chunk,
+                "docId": meta.get("doc_id", ""),
+                "docName": meta.get("doc_name", ""),
+                "score": round(1.0 / (1.0 + max(0.0, float(dist))), 3),
+            })
+        return sources
+    except Exception:
+        return []
+
+
+def _generate_answer(question: str, context: str) -> str:
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        return f"Context found: {context[:500]}"
+    import anthropic
+
+    client_llm = anthropic.Anthropic(api_key=api_key)
+    prompt = (
+        "Answer the question using only the context below from sample documents. "
+        "Be concise and specific; if the context does not contain the answer, say so.\n\n"
+        f"Context:\n{context}\n\nQuestion: {question}\n\nAnswer:"
+    )
+    response = client_llm.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],  # type: ignore[list-item]
+    )
+    block = response.content[0] if response.content else None
+    return block.text if block and hasattr(block, "text") else ""  # type: ignore[union-attr]
+
+
+def answer_demo_question(question: str, doc_id: str | None = None) -> dict:
+    """Answer a question against the sample documents, with sources. Cached per (doc, question)."""
+    cache_key = (doc_id or "all", " ".join(question.lower().split()))
+    cached = _answer_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    ensure_indexed()
+    sources = retrieve_demo_chunks(question, doc_id)
+    result: dict
+    if not sources:
+        result = {
+            "answer": "I could not find relevant information in the sample documents.",
+            "sources": [],
+        }
+    else:
+        context = "\n\n".join(s["chunk"] for s in sources)
+        result = {"answer": _generate_answer(question, context), "sources": sources}
+    _answer_cache[cache_key] = result
+    return result

--- a/packages/backend/tests/test_demo.py
+++ b/packages/backend/tests/test_demo.py
@@ -1,0 +1,130 @@
+"""Tests for the public no-auth demo endpoints (issue #200)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import api_endpoints.demo.handler as demo_handler
+import services.demo as demo_service
+
+
+@pytest.fixture(autouse=True)
+def _reset_demo_state():
+    demo_handler._question_counts.clear()
+    demo_service._answer_cache.clear()
+    yield
+    demo_handler._question_counts.clear()
+    demo_service._answer_cache.clear()
+
+
+_FAKE_ANSWER = {
+    "answer": "The company has $312 million in cash.",
+    "sources": [
+        {
+            "chunk": "We ended the year with $312 million in cash and equivalents.",
+            "docId": "demo-annual-report",
+            "docName": "Meridian Robotics 2025 Annual Report",
+            "score": 0.91,
+        }
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/demo/documents
+# ---------------------------------------------------------------------------
+
+def test_list_demo_documents_no_auth(client):
+    resp = client.get("/api/demo/documents")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body["documents"]) == 3
+    assert body["questionLimit"] == 5
+    assert body["remaining"] == 5
+    for doc in body["documents"]:
+        assert doc["id"] and doc["name"] and doc["category"]
+        assert len(doc["suggestedQuestions"]) == 3
+
+
+def test_demo_sample_files_exist():
+    for doc in demo_service.DEMO_DOCS:
+        path = demo_service.DEMO_DIR / doc["file"]
+        assert path.is_file(), f"missing demo file: {path}"
+        assert len(path.read_text(encoding="utf-8")) > 500
+
+
+# ---------------------------------------------------------------------------
+# POST /api/demo/ask
+# ---------------------------------------------------------------------------
+
+def test_ask_demo_no_auth_returns_answer_and_sources(client):
+    with patch("api_endpoints.demo.handler.ensure_indexed"), \
+         patch("api_endpoints.demo.handler.answer_demo_question", return_value=_FAKE_ANSWER):
+        resp = client.post("/api/demo/ask", json={"question": "How much cash?"})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["answer"] == _FAKE_ANSWER["answer"]
+    assert body["sources"][0]["docName"] == "Meridian Robotics 2025 Annual Report"
+    assert body["remaining"] == 4
+
+
+def test_ask_demo_requires_question(client):
+    resp = client.post("/api/demo/ask", json={})
+    assert resp.status_code == 400
+
+
+def test_ask_demo_rejects_overlong_question(client):
+    resp = client.post("/api/demo/ask", json={"question": "x" * 501})
+    assert resp.status_code == 400
+
+
+def test_ask_demo_unknown_document(client):
+    resp = client.post("/api/demo/ask", json={"question": "hi", "docId": "not-a-demo-doc"})
+    assert resp.status_code == 404
+
+
+def test_ask_demo_enforces_five_question_limit(client):
+    with patch("api_endpoints.demo.handler.ensure_indexed"), \
+         patch("api_endpoints.demo.handler.answer_demo_question", return_value=_FAKE_ANSWER):
+        for expected_remaining in (4, 3, 2, 1, 0):
+            resp = client.post("/api/demo/ask", json={"question": "q?"})
+            assert resp.status_code == 200
+            assert resp.get_json()["remaining"] == expected_remaining
+        resp = client.post("/api/demo/ask", json={"question": "one more?"})
+    assert resp.status_code == 429
+    body = resp.get_json()
+    assert body["signupRequired"] is True
+    assert body["remaining"] == 0
+
+
+def test_ask_demo_limit_reflected_in_document_listing(client):
+    with patch("api_endpoints.demo.handler.ensure_indexed"), \
+         patch("api_endpoints.demo.handler.answer_demo_question", return_value=_FAKE_ANSWER):
+        client.post("/api/demo/ask", json={"question": "q?"})
+        client.post("/api/demo/ask", json={"question": "r?"})
+    resp = client.get("/api/demo/documents")
+    assert resp.get_json()["remaining"] == 3
+
+
+# ---------------------------------------------------------------------------
+# services.demo caching
+# ---------------------------------------------------------------------------
+
+def test_answer_demo_question_caches_identical_questions():
+    sources = [{"chunk": "text", "docId": "demo-llm-paper", "docName": "Paper", "score": 0.8}]
+    with patch("services.demo.ensure_indexed"), \
+         patch("services.demo.retrieve_demo_chunks", return_value=sources), \
+         patch("services.demo._generate_answer", return_value="cached answer") as mock_gen:
+        first = demo_service.answer_demo_question("What Chunk size  worked best?")
+        second = demo_service.answer_demo_question("what chunk size worked best?")
+    assert first == second
+    assert mock_gen.call_count == 1
+
+
+def test_answer_demo_question_no_sources():
+    with patch("services.demo.ensure_indexed"), \
+         patch("services.demo.retrieve_demo_chunks", return_value=[]):
+        result = demo_service.answer_demo_question("unanswerable?")
+    assert result["sources"] == []
+    assert "could not find" in result["answer"]

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2,6 +2,7 @@ import axios from "axios";
 import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ChatPage from "./pages/ChatPage";
+import DemoPage from "./pages/DemoPage";
 import DocumentsPage from "./pages/DocumentsPage";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
@@ -158,6 +159,7 @@ export default function App() {
             <Route path="/blog" element={<BlogPage />} />
             <Route path="/careers" element={<CareersPage />} />
             <Route path="/case-studies" element={<CaseStudiesPage />} />
+            <Route path="/demo" element={<DemoPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
             <Route path="/oauth/callback" element={<OAuthCallbackPage />} />

--- a/packages/web/src/landing_page/Hero.jsx
+++ b/packages/web/src/landing_page/Hero.jsx
@@ -23,10 +23,16 @@ function Hero() {
 
       <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
         <Link
-          to="/register"
+          to="/demo"
           className="px-6 py-3 rounded-lg font-medium bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100 transition-colors"
         >
-          Try Panacea free
+          Try the live demo
+        </Link>
+        <Link
+          to="/register"
+          className="px-6 py-3 rounded-lg font-medium border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-[#2F2F2F] transition-colors"
+        >
+          Sign up free
         </Link>
         <a
           href="#versions"

--- a/packages/web/src/landing_page/Navbar.jsx
+++ b/packages/web/src/landing_page/Navbar.jsx
@@ -41,6 +41,12 @@ function Navbar() {
             {dark ? "☀️" : "🌙"}
           </button>
           <Link
+            to="/demo"
+            className="px-4 py-2 rounded-lg text-sm font-medium text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-[#2F2F2F]"
+          >
+            Live demo
+          </Link>
+          <Link
             to="/login"
             className="px-4 py-2 rounded-lg text-sm font-medium text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-[#2F2F2F]"
           >

--- a/packages/web/src/pages/DemoPage.tsx
+++ b/packages/web/src/pages/DemoPage.tsx
@@ -1,0 +1,296 @@
+import axios from 'axios';
+import { useEffect, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Link } from 'react-router-dom';
+import remarkGfm from 'remark-gfm';
+import RocketLogo from '../components/RocketLogo';
+import { useTheme } from '../App';
+
+interface DemoDoc {
+  id: string;
+  name: string;
+  category: string;
+  suggestedQuestions: string[];
+}
+
+interface DemoSource {
+  chunk: string;
+  docId: string;
+  docName: string;
+  score: number;
+}
+
+interface DemoMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  sources?: DemoSource[];
+}
+
+function SourceList({ sources }: { sources: DemoSource[] }) {
+  const [open, setOpen] = useState(false);
+  if (!sources.length) return null;
+  return (
+    <div className="mt-3 border-t border-gray-200 dark:border-gray-700 pt-2">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+      >
+        {open ? '▾' : '▸'} Sources ({sources.length})
+      </button>
+      {open && (
+        <ul className="mt-2 space-y-2">
+          {sources.map((s, i) => (
+            <li key={i} className="rounded-lg bg-[#F7F7F8] dark:bg-[#212121] p-3 text-xs">
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <span className="font-medium truncate">{s.docName}</span>
+                <span className="text-gray-400 dark:text-gray-500 flex-shrink-0">
+                  relevance {Math.round(s.score * 100)}%
+                </span>
+              </div>
+              <p className="text-gray-600 dark:text-gray-300 whitespace-pre-wrap line-clamp-6">
+                {s.chunk}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function DemoPage() {
+  const { dark, toggle } = useTheme();
+  const [docs, setDocs] = useState<DemoDoc[]>([]);
+  const [selectedDoc, setSelectedDoc] = useState<string | null>(null);
+  const [messages, setMessages] = useState<DemoMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const [limit, setLimit] = useState(5);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    axios
+      .get('/api/demo/documents')
+      .then((res) => {
+        setDocs(res.data.documents || []);
+        setRemaining(res.data.remaining ?? 5);
+        setLimit(res.data.questionLimit ?? 5);
+      })
+      .catch(() => setError('The demo backend is not reachable right now.'));
+  }, []);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, loading]);
+
+  const outOfQuestions = remaining !== null && remaining <= 0;
+
+  const ask = async (question: string) => {
+    const q = question.trim();
+    if (!q || loading || outOfQuestions) return;
+    setInput('');
+    setError(null);
+    setMessages((m) => [...m, { role: 'user', content: q }]);
+    setLoading(true);
+    try {
+      const res = await axios.post('/api/demo/ask', {
+        question: q,
+        docId: selectedDoc || undefined,
+      });
+      setMessages((m) => [
+        ...m,
+        { role: 'assistant', content: res.data.answer, sources: res.data.sources },
+      ]);
+      setRemaining(res.data.remaining);
+    } catch (e: any) {
+      if (e?.response?.status === 429) {
+        setRemaining(0);
+      } else {
+        setError('Something went wrong answering that question. Please try again.');
+        setMessages((m) => m.slice(0, -1));
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const used = remaining === null ? 0 : limit - remaining;
+
+  return (
+    <div className="min-h-screen flex flex-col bg-white dark:bg-[#212121] text-gray-900 dark:text-white">
+      {/* Header */}
+      <header className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+        <Link to="/" className="flex items-center gap-2 font-semibold">
+          <RocketLogo className="w-6 h-6" />
+          Anote
+          <span className="ml-2 text-xs font-medium px-2 py-0.5 rounded-full bg-[#F7F7F8] dark:bg-[#2F2F2F] text-gray-500 dark:text-gray-400">
+            Live demo — no sign-up
+          </span>
+        </Link>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={toggle}
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-[#2F2F2F] transition-colors"
+            aria-label="Toggle theme"
+          >
+            {dark ? '☀️' : '🌙'}
+          </button>
+          <Link
+            to="/register"
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100 transition-colors"
+          >
+            Sign up free
+          </Link>
+        </div>
+      </header>
+
+      <div className="flex-1 flex flex-col lg:flex-row max-w-6xl w-full mx-auto">
+        {/* Document picker */}
+        <aside className="lg:w-72 flex-shrink-0 p-4 lg:border-r border-gray-200 dark:border-gray-700">
+          <h2 className="text-sm font-semibold mb-3">Sample documents</h2>
+          <button
+            onClick={() => setSelectedDoc(null)}
+            className={`w-full text-left mb-2 rounded-xl border p-3 text-sm transition-colors ${
+              selectedDoc === null
+                ? 'border-gray-900 dark:border-white bg-[#F7F7F8] dark:bg-[#2F2F2F]'
+                : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-[#2F2F2F]'
+            }`}
+          >
+            All documents
+          </button>
+          {docs.map((doc) => (
+            <button
+              key={doc.id}
+              onClick={() => setSelectedDoc(doc.id)}
+              className={`w-full text-left mb-2 rounded-xl border p-3 transition-colors ${
+                selectedDoc === doc.id
+                  ? 'border-gray-900 dark:border-white bg-[#F7F7F8] dark:bg-[#2F2F2F]'
+                  : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-[#2F2F2F]'
+              }`}
+            >
+              <div className="text-xs font-medium text-gray-400 dark:text-gray-500 mb-0.5">
+                {doc.category}
+              </div>
+              <div className="text-sm font-medium leading-snug">{doc.name}</div>
+            </button>
+          ))}
+        </aside>
+
+        {/* Chat area */}
+        <main className="flex-1 flex flex-col p-4 min-h-0">
+          <div className="flex-1 overflow-y-auto">
+            {messages.length === 0 && (
+              <div className="mt-8 text-center">
+                <h1 className="text-2xl font-bold">Ask these documents anything</h1>
+                <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                  {limit} free questions, answered with source citations. No account needed.
+                </p>
+                <div className="mt-6 flex flex-wrap justify-center gap-2 max-w-xl mx-auto">
+                  {(selectedDoc
+                    ? docs.filter((d) => d.id === selectedDoc)
+                    : docs
+                  ).flatMap((d) =>
+                    d.suggestedQuestions.map((q) => (
+                      <button
+                        key={`${d.id}-${q}`}
+                        onClick={() => ask(q)}
+                        disabled={outOfQuestions || loading}
+                        className="px-3 py-1.5 rounded-full border border-gray-300 dark:border-gray-600 text-sm hover:bg-gray-100 dark:hover:bg-[#2F2F2F] disabled:opacity-40 transition-colors"
+                      >
+                        {q}
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-4 py-2">
+              {messages.map((msg, i) =>
+                msg.role === 'user' ? (
+                  <div key={i} className="flex justify-end">
+                    <div className="max-w-[85%] rounded-2xl bg-[#F7F7F8] dark:bg-[#2F2F2F] px-4 py-2.5 text-sm">
+                      {msg.content}
+                    </div>
+                  </div>
+                ) : (
+                  <div key={i} className="max-w-[95%]">
+                    <div className="rounded-2xl border border-gray-200 dark:border-gray-700 px-4 py-3 text-sm prose prose-sm dark:prose-invert max-w-none">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
+                      <SourceList sources={msg.sources || []} />
+                    </div>
+                  </div>
+                )
+              )}
+              {loading && (
+                <div className="text-sm text-gray-400 dark:text-gray-500 animate-pulse">
+                  Reading the documents…
+                </div>
+              )}
+              <div ref={bottomRef} />
+            </div>
+          </div>
+
+          {/* Sign-up gate */}
+          {outOfQuestions && (
+            <div className="mb-3 rounded-2xl border border-gray-300 dark:border-gray-600 bg-[#F7F7F8] dark:bg-[#2F2F2F] p-4 text-center">
+              <p className="font-medium">You've used all {limit} free questions</p>
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Create a free account to keep asking — and to upload your own documents.
+              </p>
+              <Link
+                to="/register"
+                className="inline-block mt-3 px-5 py-2.5 rounded-lg font-medium bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100 transition-colors"
+              >
+                Sign up free
+              </Link>
+            </div>
+          )}
+
+          {error && (
+            <div className="mb-3 text-sm text-red-500 text-center">{error}</div>
+          )}
+
+          {/* Input */}
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              ask(input);
+            }}
+            className="flex items-end gap-2 rounded-2xl border border-gray-300 dark:border-gray-600 bg-[#F7F7F8] dark:bg-[#2F2F2F] p-2"
+          >
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder={
+                outOfQuestions
+                  ? 'Sign up to keep asking questions'
+                  : selectedDoc
+                    ? `Ask about ${docs.find((d) => d.id === selectedDoc)?.name ?? 'this document'}…`
+                    : 'Ask a question about the sample documents…'
+              }
+              disabled={outOfQuestions || loading}
+              maxLength={500}
+              className="flex-1 bg-transparent px-2 py-2 text-sm outline-none disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              disabled={!input.trim() || loading || outOfQuestions}
+              className="p-2 rounded-lg bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              aria-label="Send question"
+            >
+              ↑
+            </button>
+          </form>
+          {remaining !== null && !outOfQuestions && (
+            <p className="mt-2 text-xs text-center text-gray-400 dark:text-gray-500">
+              {used} of {limit} free questions used
+            </p>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements #200 end to end: a public `/demo` route where visitors ask questions against pre-loaded sample documents with **no account**, see **source citations** for every answer, and hit a **sign-up prompt after 5 questions**.

### Backend (`/api/demo`, no auth)
- `GET /api/demo/documents` — the 3 bundled samples plus the caller's remaining free questions
- `POST /api/demo/ask` — RAG answer with `sources: [{chunk, docId, docName, score}]`; per-client (IP) limit of 5, then `429 {signupRequired: true}`; answers cached per (doc, normalized question) to avoid redundant LLM calls
- Sample docs are indexed lazily into a dedicated Chroma collection, fully separate from user documents

### Sample documents
Original content bundled in `packages/backend/demo_data/` — a fictional annual report (financial), a research-paper-style document about document Q&A (academic), and a sample employment agreement (legal). The issue suggested the Tesla 10-K and a published LLM paper; bundling those means a huge repo blob and third-party copyright, so these are purpose-written equivalents covering the same three audiences, each clearly labeled as a sample.

### Web
- New `/demo` page: document picker, suggested-question chips per document, ChatGPT-style chat in light/dark, collapsible **Sources** under each answer with relevance %, live "n of 5 free questions used" counter, and a sign-up gate when the limit is reached
- Landing page hero's primary CTA is now **Try the live demo**; navbar gains a **Live demo** link

## Testing
- 10 new backend tests: no-auth access, citations in responses, input validation, the 5-question limit (including the 429 payload), listing reflecting used questions, answer caching, sample-file presence — 245 total pass, coverage 83.7% (gate 80%)
- `ruff` clean; web `npm run build` (tsc + vite) passes