### PR TITLE
fix(desktop): app could never launch (PORT env mismatch) + private backend exposed to LAN

### DIFF
--- a/packages/backend/app.py
+++ b/packages/backend/app.py
@@ -67,6 +67,7 @@ def create_app(config: dict | None = None) -> Flask:
 
 if __name__ == "__main__":
     app = create_app()
+    host = os.environ.get("HOST", "0.0.0.0")
     port = int(os.environ.get("PORT", 5000))
     debug = os.environ.get("APP_ENV", "local") == "local"
-    app.run(host="0.0.0.0", port=port, debug=debug)
+    app.run(host=host, port=port, debug=debug)

--- a/packages/desktop/main.js
+++ b/packages/desktop/main.js
@@ -17,20 +17,29 @@ const isDev = process.env.NODE_ENV === "development" || !app.isPackaged;
 
 // Spawn bundled backend executable
 function startBackend() {
+  // The backend reads PORT (not FLASK_PORT) and binds HOST; keep it loopback-only
+  // so the desktop backend is never reachable from the local network.
+  const backendEnv = {
+    ...process.env,
+    PORT: String(BACKEND_PORT),
+    HOST: "127.0.0.1",
+  };
   let backendPath;
   if (isDev) {
-    // In dev, start Python directly
+    // In dev, start Python directly ("python" does not exist on modern macOS/Linux)
+    const pythonBin = process.platform === "win32" ? "python" : "python3";
     backendPath = path.join(__dirname, "..", "backend", "app.py");
-    backendProcess = spawn("python", [backendPath], {
-      env: { ...process.env, FLASK_PORT: String(BACKEND_PORT), APP_ENV: "local" },
+    backendProcess = spawn(pythonBin, [backendPath], {
+      env: { ...backendEnv, APP_ENV: "local" },
       stdio: "pipe",
     });
   } else {
-    // In production, use the bundled executable
+    // In production, use the bundled executable; APP_ENV=production keeps Flask
+    // debug mode (and its interactive debugger + reloader fork) off.
     const exeName = process.platform === "win32" ? "anote-backend.exe" : "anote-backend";
     backendPath = path.join(process.resourcesPath, "backend-dist", exeName);
     backendProcess = spawn(backendPath, [], {
-      env: { ...process.env, FLASK_PORT: String(BACKEND_PORT) },
+      env: { ...backendEnv, APP_ENV: "production" },
       stdio: "pipe",
     });
   }


### PR DESCRIPTION
## Summary

Three defects in how the desktop (Private GPT) app spawns its bundled backend — the first one means **the desktop app has never been able to launch**:

1. **Port env mismatch (launch-blocking).** `main.js` passed `FLASK_PORT=5099` to the backend, but `app.py` only reads `PORT` (defaulting to 5000). The backend booted on 5000, Electron health-polled 5099 for 30 seconds, then showed *"Failed to start the Anote AI backend"* and quit — every user, every launch, dev and packaged alike (`FLASK_PORT` appears nowhere in the backend). Now passes `PORT`.
2. **`spawn("python")` in dev.** The bare `python` binary doesn't exist on macOS 12.3+ or Debian/Ubuntu → silent `ENOENT` followed by the same 30-second hang. Now uses `python3` on non-Windows platforms.
3. **Packaged backend ran a debug server on `0.0.0.0`.** The production spawn set no `APP_ENV`, so Flask defaulted to `debug=True` — Werkzeug's interactive debugger, plus a reloader child process that survives `backendProcess.kill()` and keeps holding the port after quit — bound to all interfaces with wildcard CORS. The app that promises *"All data stays private on your device"* was reachable from any device on the same network. The spawn env now sets `APP_ENV=production` and `HOST=127.0.0.1`; `app.py`'s bind host is env-driven with the previous `0.0.0.0` default so Docker/server deployments are unchanged.

## Relationship to #268
Complements it — #268 hardens token storage and BYOK but keeps the same `FLASK_PORT` / `python` spawn (its `isBackendAlive()` polls the same never-answering port), so it needs this fix underneath it. Small merge conflict expected in `startBackend()`; happy to rebase whichever lands second.

## Testing
- `node --check` on `main.js`
- Backend: 235 tests pass; `ruff` clean (`app.py` change is a two-line, backward-compatible env read)