### PR TITLE
Coding workspace: connect a repo and browse its file tree

### DIFF
--- a/packages/backend/api_endpoints/coding/handler.py
+++ b/packages/backend/api_endpoints/coding/handler.py
@@ -1,0 +1,109 @@
+"""Coding workspace endpoints — connect a GitHub repo and browse its files."""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request
+
+coding_bp = Blueprint("coding", __name__, url_prefix="/api/coding")
+
+CODING_WORKSPACES_DIR = Path(os.environ.get("CODING_WORKSPACES_DIR", "/tmp/anote_coding_workspaces"))
+CODING_WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+
+# Only plain github.com HTTPS repo URLs — prevents git-clone from being used
+# as an SSRF/local-file-read vector via file://, internal hosts, etc.
+_GITHUB_URL_RE = re.compile(
+    r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\.git)?/?$"
+)
+
+_MAX_FILE_BYTES = 1_000_000  # 1MB cap on raw file content returned to the viewer
+
+_repos: dict[str, dict] = {}  # repoId -> {"path": str, "repoUrl": str}
+
+
+def _build_tree(root: Path, current: Path) -> dict:
+    """Recursively build a JSON-serializable file tree, excluding .git."""
+    rel = current.relative_to(root)
+    node = {
+        "name": current.name if rel != Path(".") else root.name,
+        "path": "" if rel == Path(".") else str(rel),
+        "type": "dir",
+        "children": [],
+    }
+    for child in sorted(current.iterdir(), key=lambda p: (p.is_file(), p.name.lower())):
+        if child.name == ".git":
+            continue
+        if child.is_dir():
+            node["children"].append(_build_tree(root, child))
+        else:
+            child_rel = child.relative_to(root)
+            node["children"].append({"name": child.name, "path": str(child_rel), "type": "file"})
+    return node
+
+
+@coding_bp.post("/connect-repo")
+def connect_repo() -> tuple:  # type: ignore[type-arg]
+    data = request.get_json(silent=True) or {}
+    repo_url = data.get("repoUrl", "").strip()
+    if not repo_url:
+        return jsonify({"error": "repoUrl is required"}), 400
+    if not _GITHUB_URL_RE.match(repo_url):
+        return jsonify({"error": "Only https://github.com/<owner>/<repo> URLs are supported"}), 400
+
+    repo_id = str(uuid.uuid4())
+    repo_path = CODING_WORKSPACES_DIR / repo_id
+    repo_path.mkdir(parents=True, exist_ok=True)
+
+    try:
+        subprocess.run(
+            ["git", "clone", "--depth", "1", repo_url, "."],
+            cwd=str(repo_path),
+            capture_output=True,
+            timeout=60,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        shutil.rmtree(repo_path, ignore_errors=True)
+        stderr = exc.stderr.decode(errors="ignore")[:500] if exc.stderr else "git clone failed"
+        return jsonify({"error": f"Failed to clone repo: {stderr}"}), 502
+    except subprocess.TimeoutExpired:
+        shutil.rmtree(repo_path, ignore_errors=True)
+        return jsonify({"error": "Cloning the repo timed out"}), 504
+
+    _repos[repo_id] = {"path": str(repo_path), "repoUrl": repo_url}
+    tree = _build_tree(repo_path, repo_path)
+    tree["name"] = repo_url.rstrip("/").removesuffix(".git").rsplit("/", 1)[-1]
+    return jsonify({"repoId": repo_id, "repoUrl": repo_url, "tree": tree}), 200
+
+
+@coding_bp.get("/repos/<repo_id>/file")
+def get_file(repo_id: str) -> tuple:  # type: ignore[type-arg]
+    repo = _repos.get(repo_id)
+    if not repo:
+        return jsonify({"error": "Repo not found. Connect it again."}), 404
+
+    rel_path = request.args.get("path", "")
+    if not rel_path:
+        return jsonify({"error": "path query param is required"}), 400
+
+    repo_root = Path(repo["path"]).resolve()
+    target = (repo_root / rel_path).resolve()
+
+    # Reject path traversal outside the cloned repo directory
+    if repo_root not in target.parents and target != repo_root:
+        return jsonify({"error": "Invalid path"}), 400
+    if not target.is_file():
+        return jsonify({"error": "File not found"}), 404
+
+    raw = target.read_bytes()
+    if b"\x00" in raw[:8000]:
+        return jsonify({"error": "Binary file preview is not supported yet"}), 415
+
+    content = raw[:_MAX_FILE_BYTES].decode("utf-8", errors="replace")
+    truncated = len(raw) > _MAX_FILE_BYTES
+    return jsonify({"path": rel_path, "content": content, "truncated": truncated}), 200

--- a/packages/backend/api_endpoints/coding/handler.py
+++ b/packages/backend/api_endpoints/coding/handler.py
@@ -29,21 +29,21 @@ _repos: dict[str, dict] = {}  # repoId -> {"path": str, "repoUrl": str}
 def _build_tree(root: Path, current: Path) -> dict:
     """Recursively build a JSON-serializable file tree, excluding .git."""
     rel = current.relative_to(root)
-    node = {
-        "name": current.name if rel != Path(".") else root.name,
-        "path": "" if rel == Path(".") else str(rel),
-        "type": "dir",
-        "children": [],
-    }
+    children: list[dict] = []
     for child in sorted(current.iterdir(), key=lambda p: (p.is_file(), p.name.lower())):
         if child.name == ".git":
             continue
         if child.is_dir():
-            node["children"].append(_build_tree(root, child))
+            children.append(_build_tree(root, child))
         else:
             child_rel = child.relative_to(root)
-            node["children"].append({"name": child.name, "path": str(child_rel), "type": "file"})
-    return node
+            children.append({"name": child.name, "path": str(child_rel), "type": "file"})
+    return {
+        "name": current.name if rel != Path(".") else root.name,
+        "path": "" if rel == Path(".") else str(rel),
+        "type": "dir",
+        "children": children,
+    }
 
 
 @coding_bp.post("/connect-repo")

--- a/packages/web/src/pages/CodingPage.tsx
+++ b/packages/web/src/pages/CodingPage.tsx
@@ -1,0 +1,187 @@
+import { useState } from "react";
+import axios from "axios";
+import { useAuth, useTheme } from "../App";
+import RocketLogo from "../components/RocketLogo";
+
+interface TreeNode {
+  name: string;
+  path: string;
+  type: "dir" | "file";
+  children?: TreeNode[];
+}
+
+function TreeItem({
+  node,
+  depth,
+  selectedPath,
+  onSelectFile,
+}: {
+  node: TreeNode;
+  depth: number;
+  selectedPath: string | null;
+  onSelectFile: (path: string) => void;
+}) {
+  const [open, setOpen] = useState(depth === 0);
+
+  if (node.type === "file") {
+    return (
+      <button
+        onClick={() => onSelectFile(node.path)}
+        className={`w-full text-left px-2 py-1 rounded-md text-sm truncate transition-colors ${
+          selectedPath === node.path
+            ? "bg-brand-blue-600 dark:bg-brand-blue-400 text-white dark:text-brand-blue-900"
+            : "text-warm-text dark:text-warm-text-dark hover:bg-warm-border dark:hover:bg-warm-border-dark"
+        }`}
+        style={{ paddingLeft: `${depth * 14 + 8}px` }}
+      >
+        {node.name}
+      </button>
+    );
+  }
+
+  return (
+    <div>
+      {depth > 0 && (
+        <button
+          onClick={() => setOpen((o) => !o)}
+          className="w-full text-left px-2 py-1 rounded-md text-sm font-medium text-warm-text dark:text-warm-text-dark hover:bg-warm-border dark:hover:bg-warm-border-dark transition-colors"
+          style={{ paddingLeft: `${depth * 14 + 8}px` }}
+        >
+          {open ? "▾" : "▸"} {node.name}
+        </button>
+      )}
+      {open &&
+        node.children?.map((child) => (
+          <TreeItem
+            key={child.path || child.name}
+            node={child}
+            depth={depth + 1}
+            selectedPath={selectedPath}
+            onSelectFile={onSelectFile}
+          />
+        ))}
+    </div>
+  );
+}
+
+export default function CodingPage() {
+  const { token } = useAuth();
+  const { dark, toggle } = useTheme();
+
+  const [repoUrl, setRepoUrl] = useState("");
+  const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [tree, setTree] = useState<TreeNode | null>(null);
+  const [repoId, setRepoId] = useState<string | null>(null);
+
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [fileContent, setFileContent] = useState<string | null>(null);
+  const [fileLoading, setFileLoading] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  const connectRepo = async () => {
+    if (!repoUrl.trim()) return;
+    setConnecting(true);
+    setConnectError(null);
+    setTree(null);
+    setRepoId(null);
+    setSelectedPath(null);
+    setFileContent(null);
+    try {
+      const res = await axios.post(
+        "/api/coding/connect-repo",
+        { repoUrl: repoUrl.trim() },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setRepoId(res.data.repoId);
+      setTree(res.data.tree);
+    } catch (err: any) {
+      setConnectError(err.response?.data?.error || "Failed to connect to repo.");
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const selectFile = async (path: string) => {
+    if (!repoId) return;
+    setSelectedPath(path);
+    setFileLoading(true);
+    setFileError(null);
+    setFileContent(null);
+    try {
+      const res = await axios.get(`/api/coding/repos/${repoId}/file`, {
+        params: { path },
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setFileContent(res.data.content);
+    } catch (err: any) {
+      setFileError(err.response?.data?.error || "Failed to load file.");
+    } finally {
+      setFileLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-warm-bg dark:bg-warm-bg-dark text-warm-text dark:text-warm-text-dark">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-warm-border dark:border-warm-border-dark">
+        <div className="flex items-center gap-2">
+          <RocketLogo className="w-7 h-7" />
+          <span className="font-semibold">Panacea Coding Workspace</span>
+        </div>
+        <button
+          onClick={toggle}
+          className="p-2 rounded-lg hover:bg-warm-card dark:hover:bg-warm-card-dark text-warm-muted dark:text-warm-muted-dark"
+          aria-label="Toggle theme"
+        >
+          {dark ? "☀️" : "🌙"}
+        </button>
+      </div>
+
+      <div className="max-w-5xl mx-auto px-6 py-8">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={repoUrl}
+            onChange={(e) => setRepoUrl(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && connectRepo()}
+            placeholder="https://github.com/owner/repo"
+            className="flex-1 px-4 py-3 rounded-lg border border-warm-border dark:border-warm-border-dark bg-warm-card dark:bg-warm-card-dark text-warm-text dark:text-warm-text-dark placeholder-warm-muted dark:placeholder-warm-muted-dark focus:outline-none focus:ring-2 focus:ring-warm-border dark:focus:ring-warm-border-dark"
+          />
+          <button
+            onClick={connectRepo}
+            disabled={connecting || !repoUrl.trim()}
+            className="px-6 py-3 rounded-lg font-medium bg-brand-blue-600 dark:bg-brand-blue-400 text-white dark:text-brand-blue-900 hover:bg-brand-blue-800 dark:hover:bg-brand-blue-200 disabled:opacity-50 transition-colors"
+          >
+            {connecting ? "Connecting..." : "Connect"}
+          </button>
+        </div>
+        {connectError && <p className="mt-2 text-sm text-red-500">{connectError}</p>}
+
+        {tree && (
+          <div className="mt-6 grid md:grid-cols-[280px,1fr] gap-6">
+            <div className="rounded-xl border border-warm-border dark:border-warm-border-dark bg-warm-card dark:bg-warm-card-dark p-2 max-h-[70vh] overflow-auto">
+              <TreeItem node={tree} depth={0} selectedPath={selectedPath} onSelectFile={selectFile} />
+            </div>
+
+            <div className="rounded-xl border border-warm-border dark:border-warm-border-dark bg-warm-card dark:bg-warm-card-dark p-4 max-h-[70vh] overflow-auto">
+              {!selectedPath && (
+                <p className="text-sm text-warm-muted dark:text-warm-muted-dark">
+                  Select a file to view its contents.
+                </p>
+              )}
+              {selectedPath && fileLoading && (
+                <p className="text-sm text-warm-muted dark:text-warm-muted-dark">Loading file...</p>
+              )}
+              {selectedPath && !fileLoading && fileError && (
+                <p className="text-sm text-red-500">{fileError}</p>
+              )}
+              {selectedPath && !fileLoading && !fileError && fileContent !== null && (
+                <pre className="whitespace-pre-wrap text-sm">{fileContent}</pre>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `CodingPage` with a GitHub repo URL input, a file tree browser, and a read-only file viewer
- New `/api/coding/connect-repo` and `/api/coding/repos/<id>/file` backend endpoints that shallow-clone a public GitHub repo and serve its file tree/contents
- Repo URL is restricted to `https://github.com/<owner>/<repo>` to prevent SSRF/local-file-read via the clone step; file reads are path-traversal-guarded to the cloned repo directory

## Test plan
- [ ] Connect a public GitHub repo URL and confirm the file tree renders
- [ ] Click through files in the tree and confirm contents render in the viewer
- [ ] Try a non-GitHub URL and confirm it's rejected

Part 1 of 3 (UI → agent buttons → routing). Next PR builds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)