### PR TITLE
Coding workspace: add 'Run agent' button

### DIFF
--- a/packages/backend/api_endpoints/coding/handler.py
+++ b/packages/backend/api_endpoints/coding/handler.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 from flask import Blueprint, jsonify, request
 
+from agents.coding_agent import run_coding_agent
+
 coding_bp = Blueprint("coding", __name__, url_prefix="/api/coding")
 
 CODING_WORKSPACES_DIR = Path(os.environ.get("CODING_WORKSPACES_DIR", "/tmp/anote_coding_workspaces"))
@@ -107,3 +109,18 @@ def get_file(repo_id: str) -> tuple:  # type: ignore[type-arg]
     content = raw[:_MAX_FILE_BYTES].decode("utf-8", errors="replace")
     truncated = len(raw) > _MAX_FILE_BYTES
     return jsonify({"path": rel_path, "content": content, "truncated": truncated}), 200
+
+
+@coding_bp.post("/repos/<repo_id>/run")
+def run_agent(repo_id: str) -> tuple:  # type: ignore[type-arg]
+    repo = _repos.get(repo_id)
+    if not repo:
+        return jsonify({"error": "Repo not found. Connect it again."}), 404
+
+    data = request.get_json(silent=True) or {}
+    prompt = data.get("prompt", "").strip()
+    if not prompt:
+        return jsonify({"error": "prompt is required"}), 400
+
+    output = run_coding_agent(prompt, cwd=repo["path"])
+    return jsonify({"output": output}), 200

--- a/packages/web/src/pages/CodingPage.tsx
+++ b/packages/web/src/pages/CodingPage.tsx
@@ -79,6 +79,11 @@ export default function CodingPage() {
   const [fileLoading, setFileLoading] = useState(false);
   const [fileError, setFileError] = useState<string | null>(null);
 
+  const [prompt, setPrompt] = useState("");
+  const [running, setRunning] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [runOutput, setRunOutput] = useState<string | null>(null);
+
   const connectRepo = async () => {
     if (!repoUrl.trim()) return;
     setConnecting(true);
@@ -99,6 +104,25 @@ export default function CodingPage() {
       setConnectError(err.response?.data?.error || "Failed to connect to repo.");
     } finally {
       setConnecting(false);
+    }
+  };
+
+  const runAgent = async () => {
+    if (!repoId || !prompt.trim()) return;
+    setRunning(true);
+    setRunError(null);
+    setRunOutput(null);
+    try {
+      const res = await axios.post(
+        `/api/coding/repos/${repoId}/run`,
+        { prompt: prompt.trim() },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setRunOutput(res.data.output);
+    } catch (err: any) {
+      setRunError(err.response?.data?.error || "Failed to run the agent.");
+    } finally {
+      setRunning(false);
     }
   };
 
@@ -179,6 +203,35 @@ export default function CodingPage() {
                 <pre className="whitespace-pre-wrap text-sm">{fileContent}</pre>
               )}
             </div>
+          </div>
+        )}
+
+        {repoId && (
+          <div className="mt-6 rounded-xl border border-warm-border dark:border-warm-border-dark bg-warm-card dark:bg-warm-card-dark p-4">
+            <p className="text-sm font-medium mb-2">Ask the coding agent</p>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && runAgent()}
+                placeholder="e.g. Summarize what this repo does"
+                className="flex-1 px-4 py-3 rounded-lg border border-warm-border dark:border-warm-border-dark bg-warm-bg dark:bg-warm-bg-dark text-warm-text dark:text-warm-text-dark placeholder-warm-muted dark:placeholder-warm-muted-dark focus:outline-none focus:ring-2 focus:ring-warm-border dark:focus:ring-warm-border-dark"
+              />
+              <button
+                onClick={runAgent}
+                disabled={running || !prompt.trim()}
+                className="px-6 py-3 rounded-lg font-medium bg-brand-blue-600 dark:bg-brand-blue-400 text-white dark:text-brand-blue-900 hover:bg-brand-blue-800 dark:hover:bg-brand-blue-200 disabled:opacity-50 transition-colors"
+              >
+                {running ? "Running..." : "Run"}
+              </button>
+            </div>
+            {runError && <p className="mt-2 text-sm text-red-500">{runError}</p>}
+            {runOutput !== null && (
+              <pre className="mt-3 whitespace-pre-wrap text-sm max-h-[40vh] overflow-auto rounded-lg bg-warm-bg dark:bg-warm-bg-dark p-3">
+                {runOutput}
+              </pre>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Adds a prompt input + "Run" button to `CodingPage` so users can ask the coding agent a question about the connected repo
- New `POST /api/coding/repos/<id>/run` endpoint that runs `agents.coding_agent.run_coding_agent` against the cloned checkout

## Test plan
- [ ] Connect a repo, type a prompt, click Run, confirm output (or a clear error if `ANTHROPIC_API_KEY` isn't set) renders below

Part 2 of 3. Builds on #287 — diff here is just the agent button/endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)