### PR TITLE
Coding workspace: wire into app routing

### DIFF
--- a/packages/backend/app.py
+++ b/packages/backend/app.py
@@ -9,6 +9,7 @@ from flask_jwt_extended import JWTManager
 
 from api_endpoints.auth.handler import auth_bp, google_oauth_callback
 from api_endpoints.chat.handler import chat_bp
+from api_endpoints.coding.handler import coding_bp
 from api_endpoints.documents.handler import documents_bp
 from api_endpoints.folders.handler import folders_bp
 from api_endpoints.payments.handler import payments_bp
@@ -45,6 +46,7 @@ def create_app(config: dict | None = None) -> Flask:
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(chat_bp)
+    app.register_blueprint(coding_bp)
     app.register_blueprint(documents_bp)
     app.register_blueprint(folders_bp)
     app.register_blueprint(search_bp)

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2,6 +2,7 @@ import axios from "axios";
 import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ChatPage from "./pages/ChatPage";
+import CodingPage from "./pages/CodingPage";
 import DocumentsPage from "./pages/DocumentsPage";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
@@ -164,6 +165,7 @@ export default function App() {
             <Route path="/app" element={<RequireAuth><ChatPage /></RequireAuth>} />
             <Route path="/app/chat/:id" element={<RequireAuth><ChatPage /></RequireAuth>} />
             <Route path="/documents" element={<RequireAuth><DocumentsPage /></RequireAuth>} />
+            <Route path="/coding" element={<RequireAuth><CodingPage /></RequireAuth>} />
           </Routes>
         </BrowserRouter>
       </AuthContext.Provider>


### PR DESCRIPTION
## Summary
- Registers `coding_bp` in the Flask app factory (`app.py`)
- Adds an authenticated `/coding` route to `App.tsx` (wrapped in `RequireAuth`, matching `/app` and `/documents`)

## Test plan
- [ ] Log in, navigate to `/coding` in the browser, confirm the coding workspace loads
- [ ] Confirm `/coding` redirects to `/login` when logged out

Part 3 of 3. Builds on #288 — this is what makes the workspace reachable in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)