### PR TITLE
fix: correct desktop release publish target and workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   publish-cli:
     name: Publish CLI to npm

--- a/packages/desktop/forge.config.js
+++ b/packages/desktop/forge.config.js
@@ -15,7 +15,7 @@ module.exports = {
     {
       name: "@electron-forge/publisher-github",
       config: {
-        repository: { owner: "anote-ai", name: "Autonomous-Intelligence" },
+        repository: { owner: "anote-ai", name: "Panacea" },
         prerelease: false,
         draft: true,
       },


### PR DESCRIPTION
## Summary

`release.yml` (triggered on `v*` tags) already publishes the CLI to npm and the VS Code extension to the Marketplace, but two bugs in the desktop-release path would have broken it in practice:

- `packages/desktop/forge.config.js` pointed `publisher-github` at the stale repo name `anote-ai/Autonomous-Intelligence` instead of `anote-ai/Panacea`, so `electron-forge publish` would try to create GitHub Releases in the wrong (now-defunct) repo.
- `release.yml` had no `permissions:` block, so on a repo with restrictive default Actions token permissions, the same publish step would 403 trying to create a release with the default `GITHUB_TOKEN`.

## Changes

- `packages/desktop/forge.config.js`: fix publisher-github repo name to `Panacea`
- `.github/workflows/release.yml`: add `permissions: contents: write`

## Test plan

- [x] Confirmed no other reference to the old repo name exists in release-critical config (remaining doc references filed as [#294](https://github.com/anote-ai/Panacea/issues/294))
- [ ] Cut a real `v*` tag from `develop` after merge to confirm `publish-desktop` creates a GitHub Release in the correct repo

Related follow-up issues filed (not blocking): #292, #293, #294, #295

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNC4dXpqHBmwk8NhbhQbHu)_