### PR TITLE
chore: swap CLI banner border color as a release-pipeline canary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   publish-cli:
     name: Publish CLI to npm

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -87,13 +87,13 @@ export function renderCliBanner(options: {
 
   return [
     "",
-    chalk.bold.hex("#4ec9b0")("┌──────────────────────────────────────────────┐"),
-    chalk.bold.hex("#4ec9b0")("│") +
+    chalk.bold.hex("#c586c0")("┌──────────────────────────────────────────────┐"),
+    chalk.bold.hex("#c586c0")("│") +
       chalk.bold.white(" Anote") +
       chalk.gray("  AI-assisted coding tool") +
       " ".repeat(15) +
-      chalk.bold.hex("#4ec9b0")("│"),
-    chalk.bold.hex("#4ec9b0")("└──────────────────────────────────────────────┘"),
+      chalk.bold.hex("#c586c0")("│"),
+    chalk.bold.hex("#c586c0")("└──────────────────────────────────────────────┘"),
     chalk.gray(`  Workspace   ${options.cwd}`),
     chalk.gray(`  Model       ${options.model}`),
     chalk.gray(`  Tools       ${options.toolsEnabled ? "enabled" : "chat-only"}`),

--- a/packages/desktop/forge.config.js
+++ b/packages/desktop/forge.config.js
@@ -15,7 +15,7 @@ module.exports = {
     {
       name: "@electron-forge/publisher-github",
       config: {
-        repository: { owner: "anote-ai", name: "Autonomous-Intelligence" },
+        repository: { owner: "anote-ai", name: "Panacea" },
         prerelease: false,
         draft: true,
       },


### PR DESCRIPTION
## Summary

Small, purely visual marker so a real release can be verified end-to-end: the `anote chat` banner box border changes from teal (`#4ec9b0`) to violet (`#c586c0`). No functional change.

Branched off `claude/panacea-release-cicd-8n4z5z` (the release-pipeline fix PR), so this PR also contains that commit until it merges first — this PR should be merged after (or together with) that one.

Once a `v*` tag is cut with this change included, a fresh `npm install -g @anote-ai/anote` should show the new violet border, confirming the npm publish actually shipped the tagged build.

## Test plan

- [x] `npm run build` in `packages/cli` succeeds
- [x] Rendered the banner locally to confirm the new color displays correctly
- [ ] After a real release, visually confirm the published package shows violet instead of teal

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNC4dXpqHBmwk8NhbhQbHu)_