### PR TITLE
Fix 8 broken tests in test_db_and_auth.py

### DIFF
--- a/packages/backend/tests/test_db_and_auth.py
+++ b/packages/backend/tests/test_db_and_auth.py
@@ -81,13 +81,17 @@ def test_register_short_password(client):
     assert resp.status_code == 400
 
 
-def test_register_falls_back_without_db(client):
-    """With no DB reachable, register still issues a token via the fallback."""
+def test_register_service_unavailable_without_db(client):
+    """No DB reachable -> register surfaces a 503, not a fake fallback token.
+
+    The fallback this test originally asserted was removed in b455823
+    ("bug fix: mysql") because it handed out tokens for users that were
+    never actually created, which left the browser holding a stale JWT.
+    """
     resp = client.post(
         "/auth/register", json={"email": "new@x.com", "password": "longenough"}
     )
-    assert resp.status_code == 201
-    assert "token" in resp.get_json()
+    assert resp.status_code == 503
 
 
 def test_login_missing_fields(client):
@@ -167,65 +171,108 @@ def test_me_with_token(client, auth_headers):
 
 
 # --- document handler edge cases ---
+#
+# Every /api/documents/* route is @require_auth, so these all need
+# auth_headers — otherwise the request never reaches the handler body
+# and every assertion below would just be checking for 401.
 
-def test_upload_no_file(client):
-    assert client.post("/api/documents/upload").status_code == 400
-
-
-def test_get_document_not_found(client):
-    assert client.get("/api/documents/nope").status_code == 404
-
-
-def test_delete_document_not_found(client):
-    assert client.delete("/api/documents/nope").status_code == 404
-
-
-def test_ask_document_not_found(client):
-    resp = client.post("/api/documents/nope/ask", json={"question": "hi"})
-    assert resp.status_code == 404
-
-
-def test_upload_unsupported_type(client):
-    import io
-
-    data = {"file": (io.BytesIO(b"binary"), "x.exe", "application/octet-stream")}
-    resp = client.post("/api/documents/upload", data=data, content_type="multipart/form-data")
+def test_upload_no_file(client, auth_headers):
+    resp = client.post("/api/documents/upload", headers=auth_headers)
     assert resp.status_code == 400
 
 
-def test_upload_and_ask_success(client, monkeypatch):
-    """Happy path with RAG mocked: upload a .txt, then ask a question."""
+def test_get_document_not_found(client, auth_headers, monkeypatch):
+    from api_endpoints.documents import handler as doc_handler
+
+    monkeypatch.setattr(doc_handler, "get_connection", lambda: FakeConnection(FakeCursor()))
+    monkeypatch.setattr(doc_handler, "get_document_by_uuid", lambda cnx, user_id, doc_id: None)
+
+    resp = client.get("/api/documents/nope", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_delete_document_not_found(client, auth_headers, monkeypatch):
+    from api_endpoints.documents import handler as doc_handler
+
+    monkeypatch.setattr(doc_handler, "get_connection", lambda: FakeConnection(FakeCursor()))
+    monkeypatch.setattr(doc_handler, "get_document_by_uuid", lambda cnx, user_id, doc_id: None)
+
+    resp = client.delete("/api/documents/nope", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_ask_document_not_found(client, auth_headers):
+    """ask_document doesn't look the doc up — it just asks the RAG layer to
+    retrieve context scoped to that id. For an id nothing was ever indexed
+    under, retrieve_context comes back empty and query_documents returns a
+    graceful "not found" answer with 200, not a 404 (see services/rag.py)."""
+    resp = client.post("/api/documents/nope/ask", json={"question": "hi"}, headers=auth_headers)
+    assert resp.status_code == 200
+    assert "could not find" in resp.get_json()["answer"].lower()
+
+
+def test_upload_unsupported_type(client, auth_headers):
+    import io
+
+    data = {"file": (io.BytesIO(b"binary"), "x.exe", "application/octet-stream")}
+    resp = client.post(
+        "/api/documents/upload", data=data, content_type="multipart/form-data", headers=auth_headers
+    )
+    assert resp.status_code == 400
+
+
+def test_upload_and_ask_success(client, auth_headers, monkeypatch):
+    """Happy path with RAG + DB mocked: upload a .txt, then ask a question."""
     import io
 
     from api_endpoints.documents import handler as doc_handler
 
+    store: dict[str, dict] = {}
+
+    def fake_create_document(cnx, user_id, doc_id, filename, chunk_count, folder_id, chat_id):
+        store[doc_id] = {
+            "id": doc_id,
+            "filename": filename,
+            "chunks": chunk_count,
+            "folder_id": folder_id,
+            "chat_id": chat_id,
+        }
+
+    monkeypatch.setattr(doc_handler, "get_connection", lambda: FakeConnection(FakeCursor()))
+    monkeypatch.setattr(doc_handler, "create_document", fake_create_document)
+    monkeypatch.setattr(doc_handler, "get_documents", lambda cnx, user_id, folder_id, chat_id: list(store.values()))
+    monkeypatch.setattr(doc_handler, "get_document_by_uuid", lambda cnx, user_id, doc_id: store.get(doc_id))
+    monkeypatch.setattr(doc_handler, "db_delete_document", lambda cnx, user_id, doc_id: store.pop(doc_id, None))
     monkeypatch.setattr(doc_handler, "ingest_document", lambda doc_id, file_path: 3)
     monkeypatch.setattr(
         doc_handler, "query_documents", lambda question, doc_ids, model: "the answer"
     )
 
     data = {"file": (io.BytesIO(b"hello world"), "notes.txt", "text/plain")}
-    up = client.post("/api/documents/upload", data=data, content_type="multipart/form-data")
+    up = client.post(
+        "/api/documents/upload", data=data, content_type="multipart/form-data", headers=auth_headers
+    )
     assert up.status_code == 201
     doc_id = up.get_json()["id"]
     assert up.get_json()["chunks"] == 3
 
     # It now appears in the listing and is fetchable.
-    assert any(d["id"] == doc_id for d in client.get("/api/documents").get_json()["documents"])
-    assert client.get(f"/api/documents/{doc_id}").status_code == 200
+    listing = client.get("/api/documents", headers=auth_headers).get_json()["documents"]
+    assert any(d["id"] == doc_id for d in listing)
+    assert client.get(f"/api/documents/{doc_id}", headers=auth_headers).status_code == 200
 
-    ask = client.post(f"/api/documents/{doc_id}/ask", json={"question": "what?"})
+    ask = client.post(f"/api/documents/{doc_id}/ask", json={"question": "what?"}, headers=auth_headers)
     assert ask.status_code == 200
     assert ask.get_json()["answer"] == "the answer"
 
     # Missing question is a 400 even for a real doc.
-    assert client.post(f"/api/documents/{doc_id}/ask", json={}).status_code == 400
+    assert client.post(f"/api/documents/{doc_id}/ask", json={}, headers=auth_headers).status_code == 400
 
     # And it can be deleted.
-    assert client.delete(f"/api/documents/{doc_id}").status_code == 200
+    assert client.delete(f"/api/documents/{doc_id}", headers=auth_headers).status_code == 200
 
 
-def test_upload_ingest_failure_returns_500(client, monkeypatch):
+def test_upload_ingest_failure_returns_500(client, auth_headers, monkeypatch):
     import io
 
     from api_endpoints.documents import handler as doc_handler
@@ -235,5 +282,7 @@ def test_upload_ingest_failure_returns_500(client, monkeypatch):
 
     monkeypatch.setattr(doc_handler, "ingest_document", boom)
     data = {"file": (io.BytesIO(b"hi"), "notes.txt", "text/plain")}
-    resp = client.post("/api/documents/upload", data=data, content_type="multipart/form-data")
+    resp = client.post(
+        "/api/documents/upload", data=data, content_type="multipart/form-data", headers=auth_headers
+    )
     assert resp.status_code == 500


### PR DESCRIPTION
## Summary

`develop`'s CI has been red for 11 days because of 8 tests in `test_db_and_auth.py` that were broken the moment they were added in 084564c ("raise coverage 81% -> 92%"). Two distinct root causes:

1. **`test_register_falls_back_without_db`** asserted `/auth/register` falls back to issuing a token when the DB is unreachable. That fallback was deliberately removed 10 days *before* this test was written, in b455823 ("bug fix: mysql") — its message explains it was handing out tokens for users that were never created, causing stale-JWT bugs in the browser. The sibling test `test_auth.py::test_register_success` was correctly updated at the time; this one wasn't. Rewrote it to assert the actual/intended 503 behavior.

2. **The other 7 tests** (`test_upload_no_file`, `test_get_document_not_found`, `test_delete_document_not_found`, `test_ask_document_not_found`, `test_upload_unsupported_type`, `test_upload_and_ask_success`, `test_upload_ingest_failure_returns_500`) never passed auth headers, so every request hit `@require_auth`'s 401 before reaching the handler logic they meant to test. Fixed by:
   - Adding the existing `auth_headers` fixture to each
   - Mocking `get_connection`/`get_document_by_uuid` for the two routes that touch the DB unconditionally before their not-found check
   - Building a small stateful fake DB (dict-backed) for `test_upload_and_ask_success` so the upload → list → get → ask → delete round-trip stays consistent
   - Correcting `test_ask_document_not_found`'s expectation from 404 to 200 — `ask_document` has no doc-existence check at all; an unknown `doc_id` just retrieves empty RAG context and returns 200 with a graceful "could not find relevant information" answer

## Test plan
- [x] `ruff check .` — clean
- [x] `mypy . --ignore-missing-imports` — clean, no issues in 54 files
- [x] `pytest tests/ -v --cov=. --cov-report=term-missing --cov-fail-under=80` — 267 passed, 0 failed, coverage 87.30% (gate is 80%)
- [x] Confirmed the 8 originally-failing tests all pass individually and as part of the full suite