### PR TITLE
ci: verify tag matches package.json version before publishing (#292)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,16 @@ jobs:
         with:
           node-version: 20.19.0
           registry-url: "https://registry.npmjs.org"
+      - name: Verify tag matches package.json version
+        working-directory: packages/cli
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match packages/cli/package.json version $PKG_VERSION"
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME matches packages/cli/package.json version $PKG_VERSION"
       - working-directory: packages/cli
         run: npm install
       - working-directory: packages/cli
@@ -37,6 +47,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.19.0
+      - name: Verify tag matches package.json version
+        working-directory: packages/vscode
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match packages/vscode/package.json version $PKG_VERSION"
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME matches packages/vscode/package.json version $PKG_VERSION"
       - working-directory: packages/vscode
         run: npm install
       - run: npm install -g @vscode/vsce


### PR DESCRIPTION
Closes #292.

## What happened

`release.yml` publishes `packages/cli` and `packages/vscode` on every `v*` tag push without ever checking the tag matches the `version` field being published. This relied entirely on a human following the README's "remember to bump the version" note. A mismatch would either fail `npm publish` with a confusing `403 You cannot publish over the previously published version`, or (for the Marketplace, which doesn't have that guard) succeed under a version that doesn't correlate to the git tag.

## Change

Adds a preflight step to both `publish-cli` and `publish-vscode`, right after `setup-node` and before `npm install` — cheap and fails fast before wasting time on install/build:

```bash
TAG_VERSION="${GITHUB_REF_NAME#v}"
PKG_VERSION="$(node -p "require('./package.json').version")"
if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
  echo "::error::Tag $GITHUB_REF_NAME does not match packages/cli/package.json version $PKG_VERSION"
  exit 1
fi
```

Per the issue's open question (hard fail vs. auto-bump): went with hard fail. A version mismatch usually means something's actually wrong with the release (wrong tag, forgot to bump, bumped the wrong package) — CI silently publishing a different version than what was tagged would just move the confusion downstream instead of resolving it.

## Test plan

- [x] Simulated locally with `GITHUB_REF_NAME` set to the current `packages/cli/package.json` version (`v1.0.5`) — passes silently
- [x] Simulated with a deliberately mismatched tag (`v9.9.9`) — fails with the `::error::` annotation and exit code 1
- [x] `.github/workflows/release.yml` parses as valid YAML
- [x] All CI checks passing on this PR (Backend, TypeScript, VS Code, Docs, CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)